### PR TITLE
Added bulk retrieval method to DiskCache

### DIFF
--- a/Stellar/IDataCache.cs
+++ b/Stellar/IDataCache.cs
@@ -8,6 +8,8 @@ public interface IDataCache
 
     Task<T?> RetrieveAsync<T>(string? cacheKey = null, string? groupKey = null);
 
+    Task<IEnumerable<T>> RetrieveManyAsync<T>(string groupKey);
+
     Task<bool> RemoveAsync<T>(string? cacheKey = null, string? groupKey = null);
 
     Task ClearCacheAsync(string? groupKey = null);


### PR DESCRIPTION
A new method, RetrieveManyAsync, has been added to the DiskCache class. This allows for retrieving multiple items from the cache at once. The method takes a groupKey and returns an IEnumerable of deserialized objects. If no files are found in the specified directory, it returns an empty list.

Additionally, several methods have been updated to accept nullable cacheDirectoryName parameters: DeserializeJsonFromFileAsync, CreateFile, GetFile and RemoveFile.
