### PR TITLE
Added bulk storage methods to DiskCache

### DIFF
--- a/Stellar.DiskDataCache/DiskCache.cs
+++ b/Stellar.DiskDataCache/DiskCache.cs
@@ -60,6 +60,22 @@ public class DiskCache : IDataCache, IDisposable
         await this.SerializeJsonToFileAsync(groupKey, cacheKey?.Invoke(item) ?? typeof(T).Name, item).ConfigureAwait(false);
     }
 
+    public async Task StoreManyAsync<T>(IEnumerable<T> items, string groupKey = null)
+    {
+        foreach (var item in items)
+        {
+            await this.SerializeJsonToFileAsync(groupKey, Guid.NewGuid().ToString("D"), item).ConfigureAwait(false);
+        }
+    }
+
+    public async Task StoreManyAsync<T>(IEnumerable<T> items, Func<T, string> cacheKey, string groupKey = null)
+    {
+        foreach (var item in items)
+        {
+            await this.SerializeJsonToFileAsync(groupKey, cacheKey(item), item).ConfigureAwait(false);
+        }
+    }
+
     public async Task<T?> RetrieveAsync<T>(string? cacheKey = null, string? groupKey = null)
     {
         return await this.DeserializeJsonFromFileAsync<T>(groupKey, cacheKey ?? typeof(T).Name).ConfigureAwait(false);

--- a/Stellar/IDataCache.cs
+++ b/Stellar/IDataCache.cs
@@ -6,6 +6,10 @@ public interface IDataCache
 
     Task StoreAsync<T>(T item, Func<T, string>? cacheKey = null, string? groupKey = null);
 
+    Task StoreManyAsync<T>(IEnumerable<T> items, string? groupKey = null);
+
+    Task StoreManyAsync<T>(IEnumerable<T> items, Func<T, string>? cacheKey = null, string? groupKey = null);
+
     Task<T?> RetrieveAsync<T>(string? cacheKey = null, string? groupKey = null);
 
     Task<IEnumerable<T>> RetrieveManyAsync<T>(string groupKey);


### PR DESCRIPTION
Two new methods have been added to the DiskCache class and IDataCache interface. These methods allow for storing multiple items at once, either with a specified cache key function or by generating a new GUID for each item. This should improve efficiency when dealing with large collections of data that need to be cached.
