### PR TITLE
Refactor item selection handling

### DIFF
--- a/Stellar.Maui/Extensions/CollectionViewExtensions.cs
+++ b/Stellar.Maui/Extensions/CollectionViewExtensions.cs
@@ -16,15 +16,9 @@ public static class CollectionViewExtensions
 
         if (deselect)
         {
-            observable
-                .Do(
-                    _ =>
-                    {
-                        if (deselect)
-                        {
-                            collectionView.SelectedItem = null;
-                        }
-                    });
+            observable =
+                observable
+                    .Do(_ => collectionView.Dispatcher.Dispatch(() => collectionView.SelectedItem = null));
         }
 
         return observable;
@@ -43,15 +37,9 @@ public static class CollectionViewExtensions
 
         if (deselect)
         {
-            observable
-                .Do(
-                    _ =>
-                    {
-                        if (deselect)
-                        {
-                            collectionView.SelectedItems = null;
-                        }
-                    });
+            observable =
+                observable
+                    .Do(_ => collectionView.Dispatcher.Dispatch(() => collectionView.SelectedItem = null));
         }
 
         return observable;

--- a/Stellar.Maui/Extensions/ListViewExtensions.cs
+++ b/Stellar.Maui/Extensions/ListViewExtensions.cs
@@ -22,16 +22,17 @@ public static class ListViewExtensions
 
         if (deselect)
         {
-            observable
-                .Do(_ => listView.Dispatcher.Dispatch(() => listView.SelectedItem = null));
+            observable =
+                observable
+                    .Do(_ => listView.Dispatcher.Dispatch(() => listView.SelectedItem = null));
         }
 
         return observable;
     }
 
-    public static IObservable<object> ItemTapped(this ListView listView)
+    public static IObservable<object> ItemTapped(this ListView listView, bool deselect = false)
     {
-        return
+        var observable =
             Observable
                 .FromEvent<EventHandler<ItemTappedEventArgs>, ItemTappedEventArgs>(
                     static eventHandler =>
@@ -42,6 +43,15 @@ public static class ListViewExtensions
                     x => listView.ItemTapped += x,
                     x => listView.ItemTapped -= x)
                 .Select(static args => args.Item);
+
+        if (deselect)
+        {
+            observable =
+                observable
+                    .Do(_ => listView.Dispatcher.Dispatch(() => listView.SelectedItem = null));
+        }
+
+        return observable;
     }
 
     public static IObservable<T> ItemSelected<T>(this ListView listView, bool deselect = false)
@@ -62,16 +72,17 @@ public static class ListViewExtensions
 
         if (deselect)
         {
-            observable
-                .Do(_ => listView.Dispatcher.Dispatch(() => listView.SelectedItem = null));
+            observable =
+                observable
+                    .Do(_ => listView.Dispatcher.Dispatch(() => listView.SelectedItem = null));
         }
 
         return observable;
     }
 
-    public static IObservable<object> ListViewItemSelected(this ListView listView)
+    public static IObservable<object> ItemSelected(this ListView listView, bool deselect = false)
     {
-        return
+        var observable =
             Observable
                 .FromEvent<EventHandler<SelectedItemChangedEventArgs>, SelectedItemChangedEventArgs>(
                     static eventHandler =>
@@ -82,5 +93,14 @@ public static class ListViewExtensions
                     x => listView.ItemSelected += x,
                     x => listView.ItemSelected -= x)
                 .Select(static args => args.SelectedItem);
+
+        if (deselect)
+        {
+            observable =
+                observable
+                    .Do(_ => listView.Dispatcher.Dispatch(() => listView.SelectedItem = null));
+        }
+
+        return observable;
     }
 }

--- a/Stellar.MauiSample/UserInterface/Pages/SamplePage.cs
+++ b/Stellar.MauiSample/UserInterface/Pages/SamplePage.cs
@@ -128,7 +128,7 @@ public class SamplePage : ContentPageBase<ViewModels.SampleViewModel>
         Observable
             .Merge(
                 _listView
-                    .ItemTapped<ViewModels.TestItem>()
+                    .ItemTapped<ViewModels.TestItem>(true)
                     .Select(static x => x.Value2),
                 this.WhenAnyObservable(static x => x.ViewModel.GoNext)
                     .Select(static _ => 0))


### PR DESCRIPTION
- Simplified deselection logic in collection and list view extensions.
- Updated methods to use a more concise syntax for setting selected items to null.
- Added optional `deselect` parameter to item tapped methods for better control.
