### PR TITLE
Simplifies Stellar component initialization

### DIFF
--- a/Stellar.Avalonia/Extensions/AppBuilderExtensions.cs
+++ b/Stellar.Avalonia/Extensions/AppBuilderExtensions.cs
@@ -8,27 +8,13 @@ namespace Stellar.Avalonia;
 
 public static class AppBuilderExtensions
 {
-    public static AppBuilder UseStellarComponents<TStellarAssembly>(this AppBuilder appBuilder)
+    public static AppBuilder UseStellarComponents(this AppBuilder appBuilder)
     {
         PlatformRegistrationManager.SetRegistrationNamespaces(RegistrationNamespace.Avalonia);
         Locator.CurrentMutable.InitializeSplat();
         Locator.CurrentMutable.InitializeReactiveUI();
         RxApp.TaskpoolScheduler = Schedulers.ShortTermThreadPoolScheduler;
 
-/*
-        services.ConfigureStellarComponents(typeof(TStellarAssembly).GetTypeInfo().Assembly);
-
-        services
-            .AddSingleton(
-                sp =>
-                {
-                    var instance = StellarDependencyResolver.Instance;
-
-                    instance.RegisterResolver((Type type) => sp.GetService(type));
-
-                    return instance;
-                });
-*/
         return appBuilder;
     }
 

--- a/Stellar.AvaloniaSample/Program.cs
+++ b/Stellar.AvaloniaSample/Program.cs
@@ -21,7 +21,7 @@ public static class Program
             .UsePlatformDetect()
             .WithInterFont()
             .LogToTrace()
-            .UseStellarComponents<App>()
+            .UseStellarComponents()
 #if DEBUG
             .EnableHotReload()
 #endif

--- a/Stellar.Blazor/Extensions/BuilderExtensions.cs
+++ b/Stellar.Blazor/Extensions/BuilderExtensions.cs
@@ -8,12 +8,19 @@ public static class BuilderExtensions
 {
     public static IServiceCollection UseStellarComponents<TStellarAssembly>(this IServiceCollection services)
     {
+        UseStellarComponents(services);
+
+        services.ConfigureStellarComponents(typeof(TStellarAssembly).GetTypeInfo().Assembly);
+
+        return services;
+    }
+
+    public static IServiceCollection UseStellarComponents(this IServiceCollection services)
+    {
         PlatformRegistrationManager.SetRegistrationNamespaces(RegistrationNamespace.Blazor);
         Locator.CurrentMutable.InitializeSplat();
         Locator.CurrentMutable.InitializeReactiveUI();
         RxApp.TaskpoolScheduler = Schedulers.ShortTermThreadPoolScheduler;
-
-        services.ConfigureStellarComponents(typeof(TStellarAssembly).GetTypeInfo().Assembly);
 
         return services;
     }

--- a/Stellar.Maui/Extensions/MauiAppBuilderExtensions.cs
+++ b/Stellar.Maui/Extensions/MauiAppBuilderExtensions.cs
@@ -19,6 +19,17 @@ public static class MauiAppBuilderExtensions
 
     public static MauiAppBuilder UseStellarComponents<TStellarAssembly>(this MauiAppBuilder mauiAppBuilder, bool useCustomMauiScheduler = true, bool useShortTermThreadPoolScheduler = true)
     {
+        UseStellarComponents(mauiAppBuilder, useCustomMauiScheduler, useShortTermThreadPoolScheduler);
+
+        mauiAppBuilder
+            .Services
+                .ConfigureStellarComponents(typeof(TStellarAssembly).GetTypeInfo().Assembly);
+
+        return mauiAppBuilder;
+    }
+
+    public static MauiAppBuilder UseStellarComponents(this MauiAppBuilder mauiAppBuilder, bool useCustomMauiScheduler = true, bool useShortTermThreadPoolScheduler = true)
+    {
         UseCustomMauiScheduler = useCustomMauiScheduler;
         UseShortTermThreadPoolScheduler = useShortTermThreadPoolScheduler;
 
@@ -26,12 +37,11 @@ public static class MauiAppBuilderExtensions
         Locator.CurrentMutable.InitializeSplat();
         Locator.CurrentMutable.InitializeReactiveUI();
 
+        mauiAppBuilder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IMauiInitializeScopedService, MauiSchedulerInitializer>());
+
         mauiAppBuilder
             .Services
-                .AddSingleton(serviceProvider => new MauiScheduler(serviceProvider.GetRequiredService<IDispatcher>()))
-                .ConfigureStellarComponents(typeof(TStellarAssembly).GetTypeInfo().Assembly);
-
-        mauiAppBuilder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IMauiInitializeScopedService, MauiSchedulerInitializer>());
+            .AddSingleton(serviceProvider => new MauiScheduler(serviceProvider.GetRequiredService<IDispatcher>()));
 
         return mauiAppBuilder;
     }

--- a/Stellar.MauiSample/MauiProgram.cs
+++ b/Stellar.MauiSample/MauiProgram.cs
@@ -24,7 +24,7 @@ public static class MauiProgram
 #if DEBUG
                 .EnableHotReload()
 #endif
-                .UseStellarComponents<App>();
+                .UseStellarComponents();
 
         appBuilder.Services.AddRegisteredServicesForStellarMauiSample();
 


### PR DESCRIPTION
Streamlines the initialization process for Stellar components across Avalonia, Blazor, and Maui.

- Removes the need to specify the assembly when initializing.
- Adds an overload for `UseStellarComponents` that doesn't require an assembly.
- Configures Stellar components with or without a specified assembly.
