### PR TITLE
Adds clear functionality to the picker

### DIFF
--- a/Stellar.Maui/Extensions/PickerExtensions.cs
+++ b/Stellar.Maui/Extensions/PickerExtensions.cs
@@ -416,6 +416,9 @@ public class ReactivePickerBinder<TViewModel> : IDisposable
             }
         }
 
+        var picker = _picker;
+        picker?.Dispatcher?.Dispatch(() => picker.ResetToInitialValue());
+
         if (fromNotificationTrigger)
         {
             SelectedItemChanged(default(TViewModel));

--- a/Stellar.MauiSample/UserInterface/Pages/SamplePopupPage.cs
+++ b/Stellar.MauiSample/UserInterface/Pages/SamplePopupPage.cs
@@ -13,6 +13,8 @@ public class SamplePopupPage : PopupPageBase<SampleViewModel>
 
     private BoxView _color;
 
+    private Button _clear;
+
     private Picker _picker;
 
     private ListView _listView;
@@ -53,6 +55,12 @@ public class SamplePopupPage : PopupPageBase<SampleViewModel>
                         VerticalOptions = LayoutOptions.Start,
                     }
                         .Assign(out _picker),
+                    new Button
+                        {
+                            Text = "Clear",
+                            VerticalOptions = LayoutOptions.Start,
+                        }
+                        .Assign(out _clear),
 
                     new ListView
                     {
@@ -80,12 +88,16 @@ public class SamplePopupPage : PopupPageBase<SampleViewModel>
             .BindTo(this, static ui => ui._color.BackgroundColor)
             .DisposeWith(disposables);
 
+        this.BindCommand(ViewModel, vm => vm.Clear, ui => ui._clear, Observables.UnitDefault)
+            .DisposeWith(disposables);
+
         _picker
             .BindPicker(
                 this.WhenAnyValue(static x => x.ViewModel.TestItems),
                 x => this.ViewModel.SelectedTestItem = x,
                 x => this.ViewModel.SelectedTestItem == x,
-                x => x.Value1)
+                x => x.Value1,
+                this.WhenAnyValue(x => x.ViewModel.SelectedTestItem))
             .DisposeWith(disposables);
 
         this.OneWayBind(ViewModel, static vm => vm.TestItems, static ui => ui._listView.ItemsSource)

--- a/Stellar.MauiSample/ViewModels/SampleViewModel.cs
+++ b/Stellar.MauiSample/ViewModels/SampleViewModel.cs
@@ -26,6 +26,9 @@ public partial class SampleViewModel(TestService testService)
     private ReactiveCommand<Unit, Unit> _goNext;
 
     [Reactive]
+    private ReactiveCommand<Unit, Unit> _clear;
+
+    [Reactive]
     private byte[] _colorArray;
 
     [Reactive]
@@ -91,6 +94,14 @@ public partial class SampleViewModel(TestService testService)
         GoNext =
             ReactiveCommand
                 .Create(DefaultAction)
+                .DisposeWith(disposables);
+
+        Clear =
+            ReactiveCommand
+                .Create(() =>
+                {
+                    SelectedTestItem = null;
+                })
                 .DisposeWith(disposables);
     }
 


### PR DESCRIPTION
Allows the user to clear the selected item in the picker, resetting it to its initial value.

*   Adds a "Clear" button to the sample popup page.
*   Binds the button's command to a new `Clear` command in the view model.
*   The `Clear` command sets the `SelectedTestItem` to null.
*   Adds logic to the picker to reset its initial value via the dispatcher.
