### PR TITLE
Migrate to ReactiveUI 24 (.Reactive), Avalonia 12, and add WPF / WinUI 3 / Uno platform heads

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -38,6 +38,18 @@ jobs:
           - name: Stellar.SourceGenerators
             project: Stellar.SourceGenerators/Stellar.SourceGenerators.csproj
             output: Stellar.SourceGenerators/bin/Release
+          # The Windows-targeted projects cross-compile on the macOS runner via
+          # EnableWindowsTargeting; Stellar.WinUI additionally disables the PRI/MSIX
+          # tooling on non-Windows hosts in its csproj.
+          - name: Stellar.Wpf
+            project: Stellar.Wpf/Stellar.Wpf.csproj
+            output: Stellar.Wpf/bin/Release
+          - name: Stellar.WinUI
+            project: Stellar.WinUI/Stellar.WinUI.csproj
+            output: Stellar.WinUI/bin/Release
+          - name: Stellar.Uno
+            project: Stellar.Uno/Stellar.Uno.csproj
+            output: Stellar.Uno/bin/Release
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-dotnet@v6

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -28,7 +28,7 @@
     <PackageVersion Include="ReactiveUI.Blazor" Version="23.2.28" />
     <PackageVersion Include="ReactiveUI.Maui" Version="23.2.28" />
     <PackageVersion Include="ReactiveGenerator" Version="0.12.0" />
-    <PackageVersion Include="ReactiveUI.SourceGenerators" Version="3.1.0" />
+    <PackageVersion Include="ReactiveUI.SourceGenerators" Version="3.2.0" />
     <PackageVersion Include="ReactiveMarbles.ObservableEvents.SourceGenerator" Version="1.3.1" />
   </ItemGroup>
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,13 +20,20 @@
     <PackageVersion Include="FluentValidation" Version="12.1.1" />
   </ItemGroup>
 
-  <!-- ReactiveUI. 21.x publishes no net10.0 target frameworks, so targeting
-       .NET 10 requires 23.x. This jump is forced by the framework rather
-       than chosen. -->
+  <!-- ReactiveUI 24 re-platformed onto ReactiveUI.Primitives and split into two
+       distributions. Stellar uses the .Reactive family (ReactiveUI.Reactive,
+       ReactiveUI.Maui.Reactive, ReactiveUI.Blazor.Reactive): it runs on the same
+       new Primitives engine as the default packages, but keeps System.Reactive 7
+       types (Unit, IScheduler, Subject<T>) at the API boundary, which Stellar's
+       public API is built on. System.Reactive is referenced directly because the
+       default ReactiveUI packages no longer pull it in transitively. -->
   <ItemGroup>
-    <PackageVersion Include="ReactiveUI" Version="23.2.28" />
-    <PackageVersion Include="ReactiveUI.Blazor" Version="23.2.28" />
-    <PackageVersion Include="ReactiveUI.Maui" Version="23.2.28" />
+    <PackageVersion Include="ReactiveUI.Reactive" Version="24.0.0" />
+    <PackageVersion Include="ReactiveUI.Blazor.Reactive" Version="24.0.0" />
+    <PackageVersion Include="ReactiveUI.Maui.Reactive" Version="24.0.0" />
+    <PackageVersion Include="ReactiveUI.WPF.Reactive" Version="24.0.0" />
+    <PackageVersion Include="ReactiveUI.WinUI.Reactive" Version="24.0.0" />
+    <PackageVersion Include="System.Reactive" Version="7.0.0" />
     <PackageVersion Include="ReactiveGenerator" Version="0.12.0" />
     <PackageVersion Include="ReactiveUI.SourceGenerators" Version="3.2.0" />
     <PackageVersion Include="ReactiveMarbles.ObservableEvents.SourceGenerator" Version="1.3.1" />
@@ -36,30 +43,38 @@
   <ItemGroup>
     <PackageVersion Include="Microsoft.Maui.Controls" Version="10.0.90" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="10.0.90" />
-    <!-- CommunityToolkit.Maui 12.x pins Microsoft.Maui.Essentials below 10.0.0,
-         so .NET 10 forces 14.x here as well. -->
-    <PackageVersion Include="CommunityToolkit.Maui" Version="14.2.2" />
-    <PackageVersion Include="CommunityToolkit.Maui.Markup" Version="7.0.1" />
+    <PackageVersion Include="CommunityToolkit.Maui" Version="15.0.0" />
+    <PackageVersion Include="CommunityToolkit.Maui.Markup" Version="8.0.0" />
     <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.2" />
     <PackageVersion Include="Mopups" Version="1.3.4" />
   </ItemGroup>
 
-  <!-- Avalonia is capped at 11.3.x: Avalonia itself has shipped 12.1.0, but
-       Avalonia.ReactiveUI has no 12.x release (not even a prerelease), and
-       Stellar.Avalonia depends on it. Revisit when 12.x lands there. -->
+  <!-- Avalonia 12. The former Avalonia.ReactiveUI dependency is gone: it has no
+       release compatible with ReactiveUI 24 (or Avalonia 12), so Stellar.Avalonia
+       now provides its own IViewFor base classes, activation fetcher and UI-thread
+       scheduler. Avalonia.Diagnostics was discontinued after 11.3 (DevTools moved
+       to the standalone Avalonia Accelerate tooling) and was referenced but unused,
+       so it is dropped rather than pinned. -->
   <ItemGroup>
-    <PackageVersion Include="Avalonia" Version="11.3.18" />
-    <PackageVersion Include="Avalonia.Desktop" Version="11.3.18" />
-    <PackageVersion Include="Avalonia.Diagnostics" Version="11.3.18" />
-    <PackageVersion Include="Avalonia.Fonts.Inter" Version="11.3.18" />
-    <PackageVersion Include="Avalonia.ReactiveUI" Version="11.3.9" />
-    <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.3.18" />
+    <PackageVersion Include="Avalonia" Version="12.1.1" />
+    <PackageVersion Include="Avalonia.Desktop" Version="12.1.1" />
+    <PackageVersion Include="Avalonia.Fonts.Inter" Version="12.1.1" />
+    <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.1.1" />
   </ItemGroup>
 
   <!-- Blazor -->
   <ItemGroup>
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.10" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.10" />
+  </ItemGroup>
+
+  <!-- Windows (WPF / WinUI 3) and Uno. There is no ReactiveUI 24-compatible Uno
+       package (ReactiveUI.Uno stopped at 23, ReactiveUI.Uno.WinUI at 20), so
+       Stellar.Uno hand-rolls its activation fetcher and scheduler the same way
+       Stellar.Avalonia does. -->
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="2.3.1" />
+    <PackageVersion Include="Uno.WinUI" Version="6.6.176" />
   </ItemGroup>
 
   <!-- Source generators. Roslyn is pinned to 5.0.0 rather than the newest

--- a/Stellar.Avalonia/AvaloniaActivationForViewFetcher.cs
+++ b/Stellar.Avalonia/AvaloniaActivationForViewFetcher.cs
@@ -1,0 +1,58 @@
+using System.Reactive.Linq;
+using Avalonia;
+using Avalonia.Controls;
+using ReactiveUI;
+
+namespace Stellar.Avalonia;
+
+/// <summary>
+/// Determines when Avalonia views are activated and deactivated so that
+/// <c>WhenActivated</c> works for them. Replaces Avalonia.ReactiveUI's
+/// AvaloniaActivationForViewFetcher, which has no release compatible with
+/// ReactiveUI 24. Windows activate on <see cref="Window.Opened"/> and deactivate on
+/// <see cref="Window.Closed"/>; other controls follow visual-tree attachment.
+/// </summary>
+public sealed class AvaloniaActivationForViewFetcher : IActivationForViewFetcher
+{
+    public int GetAffinityForView(Type view) =>
+        typeof(Visual).IsAssignableFrom(view) ? 10 : 0;
+
+    public IObservable<bool> GetActivationForView(IActivatableView view)
+    {
+        if (view is Window window)
+        {
+            var opened = Observable
+                .FromEventPattern<EventHandler, EventArgs>(
+                    handler => window.Opened += handler,
+                    handler => window.Opened -= handler)
+                .Select(static _ => true);
+
+            var closed = Observable
+                .FromEventPattern<EventHandler, EventArgs>(
+                    handler => window.Closed += handler,
+                    handler => window.Closed -= handler)
+                .Select(static _ => false);
+
+            return opened.Merge(closed).DistinctUntilChanged();
+        }
+
+        if (view is Control control)
+        {
+            var attached = Observable
+                .FromEventPattern<EventHandler<VisualTreeAttachmentEventArgs>, VisualTreeAttachmentEventArgs>(
+                    handler => control.AttachedToVisualTree += handler,
+                    handler => control.AttachedToVisualTree -= handler)
+                .Select(static _ => true);
+
+            var detached = Observable
+                .FromEventPattern<EventHandler<VisualTreeAttachmentEventArgs>, VisualTreeAttachmentEventArgs>(
+                    handler => control.DetachedFromVisualTree += handler,
+                    handler => control.DetachedFromVisualTree -= handler)
+                .Select(static _ => false);
+
+            return attached.Merge(detached).DistinctUntilChanged();
+        }
+
+        return Observable.Return(false);
+    }
+}

--- a/Stellar.Avalonia/AvaloniaScheduler.cs
+++ b/Stellar.Avalonia/AvaloniaScheduler.cs
@@ -1,0 +1,75 @@
+using System.Reactive.Concurrency;
+using System.Reactive.Disposables;
+using Avalonia.Threading;
+
+namespace Stellar.Avalonia;
+
+/// <summary>
+/// An <see cref="IScheduler"/> that schedules work onto the Avalonia UI thread.
+/// Replaces Avalonia.ReactiveUI's AvaloniaScheduler, which has no release compatible
+/// with ReactiveUI 24. Work scheduled with no due time from the UI thread runs inline.
+/// </summary>
+public sealed class AvaloniaScheduler : IScheduler
+{
+    private AvaloniaScheduler()
+    {
+    }
+
+    public static AvaloniaScheduler Instance { get; } = new();
+
+    public DateTimeOffset Now => DateTimeOffset.Now;
+
+    public IDisposable Schedule<TState>(TState state, Func<IScheduler, TState, IDisposable> action)
+    {
+        var innerDisp = new SingleAssignmentDisposable();
+
+        if (Dispatcher.UIThread.CheckAccess())
+        {
+            innerDisp.Disposable = action(this, state);
+
+            return innerDisp;
+        }
+
+        Dispatcher.UIThread.Post(
+            () =>
+            {
+                if (!innerDisp.IsDisposed)
+                {
+                    innerDisp.Disposable = action(this, state);
+                }
+            });
+
+        return innerDisp;
+    }
+
+    public IDisposable Schedule<TState>(TState state, TimeSpan dueTime, Func<IScheduler, TState, IDisposable> action)
+    {
+        if (dueTime <= TimeSpan.Zero)
+        {
+            return Schedule(state, action);
+        }
+
+        var innerDisp = new SingleAssignmentDisposable();
+
+        var timer = DispatcherTimer.RunOnce(
+            () =>
+            {
+                if (!innerDisp.IsDisposed)
+                {
+                    innerDisp.Disposable = action(this, state);
+                }
+            },
+            dueTime);
+
+        return new CompositeDisposable(timer, innerDisp);
+    }
+
+    public IDisposable Schedule<TState>(TState state, DateTimeOffset dueTime, Func<IScheduler, TState, IDisposable> action)
+    {
+        var relative = dueTime - Now;
+
+        return relative <= TimeSpan.Zero
+            ? Schedule(state, action)
+            : Schedule(state, relative, action);
+    }
+}

--- a/Stellar.Avalonia/Extensions/AppBuilderExtensions.cs
+++ b/Stellar.Avalonia/Extensions/AppBuilderExtensions.cs
@@ -1,9 +1,8 @@
 ﻿using System.Reflection;
 using Avalonia;
-using Avalonia.ReactiveUI;
 using Microsoft.Extensions.DependencyInjection;
 using ReactiveUI;
-using ReactiveUI.Builder;
+using ReactiveUI.Reactive.Builder;
 using Splat;
 
 namespace Stellar.Avalonia;
@@ -12,24 +11,19 @@ public static class AppBuilderExtensions
 {
     public static AppBuilder UseStellarComponents(this AppBuilder appBuilder)
     {
-        // Avalonia.ReactiveUI 11.3.9 was built against ReactiveUI 20 and its
-        // bootstrap types -- Registrations and AvaloniaMixins.UseReactiveUI --
-        // reference RxApp, PlatformRegistrationManager and Splat's IEnableLogger,
-        // all removed in ReactiveUI 23 / Splat 19. Those types now fail to load,
-        // so Stellar performs the registrations itself. The pieces it needs
-        // (AvaloniaActivationForViewFetcher, AvaloniaScheduler,
-        // AutoDataTemplateBindingHook, and the ReactiveWindow/ReactiveUserControl
-        // base classes) all load and work against ReactiveUI 23.
+        // Avalonia.ReactiveUI has no release compatible with ReactiveUI 24 (or with
+        // Avalonia 12), so Stellar no longer references it and provides the pieces it
+        // needs itself: Stellar's own AvaloniaActivationForViewFetcher and
+        // AvaloniaScheduler here, and the IViewFor implementations in
+        // WindowBase/UserControlBase. Avalonia.ReactiveUI's AutoDataTemplateBindingHook
+        // is intentionally not re-implemented: it only supplied automatic data
+        // templates for ViewModelViewHost, which Stellar's view management never uses.
         Locator.CurrentMutable.InitializeSplat();
 
         RxAppBuilder
             .CreateReactiveUIBuilder()
             .WithRegistration(
-                static resolver =>
-                {
-                    resolver.RegisterConstant<IActivationForViewFetcher>(new AvaloniaActivationForViewFetcher());
-                    resolver.RegisterConstant<IPropertyBindingHook>(new AutoDataTemplateBindingHook());
-                })
+                static resolver => resolver.RegisterConstant<IActivationForViewFetcher>(new AvaloniaActivationForViewFetcher()))
             .WithMainThreadScheduler(AvaloniaScheduler.Instance)
             .WithTaskPoolScheduler(Schedulers.ShortTermThreadPoolScheduler)
             .Build();

--- a/Stellar.Avalonia/Stellar.Avalonia.csproj
+++ b/Stellar.Avalonia/Stellar.Avalonia.csproj
@@ -21,9 +21,6 @@
     <PackageReference Include="Avalonia.Desktop" />
     <PackageReference Include="Avalonia.Themes.Fluent" />
     <PackageReference Include="Avalonia.Fonts.Inter" />
-    <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" />
-    <PackageReference Include="Avalonia.ReactiveUI" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.AutoActivation" />
   </ItemGroup>
   <ItemGroup>

--- a/Stellar.Avalonia/UserControlBase.cs
+++ b/Stellar.Avalonia/UserControlBase.cs
@@ -1,16 +1,35 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 using System.Reactive;
 using System.Reactive.Disposables;
 using Avalonia;
-using Avalonia.ReactiveUI;
+using Avalonia.Controls;
+using ReactiveUI;
 
 namespace Stellar.Avalonia;
 
-public abstract class UserControlBase<TViewModel> : ReactiveUserControl<TViewModel>, IStellarView<TViewModel>
+// Derives from UserControl directly and implements IViewFor itself: this base class
+// previously came from Avalonia.ReactiveUI's ReactiveUserControl, which has no release
+// compatible with ReactiveUI 24.
+public abstract class UserControlBase<TViewModel> : UserControl, IStellarView<TViewModel>
     where TViewModel : class
 {
+    public static readonly StyledProperty<TViewModel?> ViewModelProperty =
+        AvaloniaProperty.Register<UserControlBase<TViewModel>, TViewModel?>(nameof(ViewModel));
+
     [EditorBrowsable(EditorBrowsableState.Never)]
     public ViewManager<TViewModel> ViewManager { get; } = new AvaloniaViewManager<TViewModel>();
+
+    public TViewModel? ViewModel
+    {
+        get => GetValue(ViewModelProperty);
+        set => SetValue(ViewModelProperty, value);
+    }
+
+    object? IViewFor.ViewModel
+    {
+        get => ViewModel;
+        set => ViewModel = value as TViewModel;
+    }
 
     public IObservable<Unit> UserControlInitialized => ViewManager.Initialized;
 
@@ -65,19 +84,51 @@ public abstract class UserControlBase<TViewModel> : ReactiveUserControl<TViewMod
         base.OnDetachedFromVisualTree(e);
     }
 
+    protected override void OnDataContextChanged(EventArgs e)
+    {
+        base.OnDataContextChanged(e);
+
+        ViewModel = DataContext as TViewModel;
+    }
+
     protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
     {
+        if (change.Property == ViewModelProperty)
+        {
+            var newViewModel = change.GetNewValue<TViewModel?>();
+
+            if (!ReferenceEquals(newViewModel, DataContext))
+            {
+                DataContext = newViewModel;
+            }
+        }
+
         ViewManager.PropertyChanged(this, change.Property.Name);
 
         base.OnPropertyChanged(change);
     }
 }
 
-public abstract class UserControlBase<TViewModel, TDataModel> : ReactiveUserControl<TViewModel>, IStellarView<TViewModel>
+public abstract class UserControlBase<TViewModel, TDataModel> : UserControl, IStellarView<TViewModel>
     where TViewModel : class
 {
+    public static readonly StyledProperty<TViewModel?> ViewModelProperty =
+        AvaloniaProperty.Register<UserControlBase<TViewModel, TDataModel>, TViewModel?>(nameof(ViewModel));
+
     [EditorBrowsable(EditorBrowsableState.Never)]
     public ViewManager<TViewModel> ViewManager { get; } = new AvaloniaViewManager<TViewModel>();
+
+    public TViewModel? ViewModel
+    {
+        get => GetValue(ViewModelProperty);
+        set => SetValue(ViewModelProperty, value);
+    }
+
+    object? IViewFor.ViewModel
+    {
+        get => ViewModel;
+        set => ViewModel = value as TViewModel;
+    }
 
     public IObservable<Unit> UserControlInitialized => ViewManager.Initialized;
 
@@ -117,6 +168,9 @@ public abstract class UserControlBase<TViewModel, TDataModel> : ReactiveUserCont
         base.OnDetachedFromVisualTree(e);
     }
 
+    // No ViewModel<->DataContext syncing here: unlike the single-parameter base class,
+    // DataContext holds a TDataModel that is mapped onto the view model, so the two
+    // properties are intentionally independent.
     protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
     {
         ViewManager.PropertyChanged(this, change.Property.Name);

--- a/Stellar.Avalonia/WindowBase.cs
+++ b/Stellar.Avalonia/WindowBase.cs
@@ -4,16 +4,34 @@ using System.Reactive;
 using System.Reactive.Disposables;
 using Avalonia;
 using Avalonia.Controls;
-using Avalonia.ReactiveUI;
+using ReactiveUI;
 using Stellar.ViewModel;
 
 namespace Stellar.Avalonia
 {
-    public abstract class WindowBase<TViewModel> : ReactiveWindow<TViewModel>, IStellarView<TViewModel>
+    // Derives from Window directly and implements IViewFor itself: this base class
+    // previously came from Avalonia.ReactiveUI's ReactiveWindow, which has no release
+    // compatible with ReactiveUI 24.
+    public abstract class WindowBase<TViewModel> : Window, IStellarView<TViewModel>
         where TViewModel : class
     {
+        public static readonly StyledProperty<TViewModel?> ViewModelProperty =
+            AvaloniaProperty.Register<WindowBase<TViewModel>, TViewModel?>(nameof(ViewModel));
+
         [EditorBrowsable(EditorBrowsableState.Never)]
         public ViewManager<TViewModel> ViewManager { get; } = new AvaloniaViewManager<TViewModel>();
+
+        public TViewModel? ViewModel
+        {
+            get => GetValue(ViewModelProperty);
+            set => SetValue(ViewModelProperty, value);
+        }
+
+        object? IViewFor.ViewModel
+        {
+            get => ViewModel;
+            set => ViewModel = value as TViewModel;
+        }
 
         public IObservable<Unit> WindowInitialized => ViewManager.Initialized;
 
@@ -77,8 +95,25 @@ namespace Stellar.Avalonia
             base.OnClosing(e);
         }
 
+        protected override void OnDataContextChanged(EventArgs e)
+        {
+            base.OnDataContextChanged(e);
+
+            ViewModel = DataContext as TViewModel;
+        }
+
         protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
         {
+            if (change.Property == ViewModelProperty)
+            {
+                var newViewModel = change.GetNewValue<TViewModel?>();
+
+                if (!ReferenceEquals(newViewModel, DataContext))
+                {
+                    DataContext = newViewModel;
+                }
+            }
+
             ViewManager.PropertyChanged(this, change.Property.Name);
 
             base.OnPropertyChanged(change);

--- a/Stellar.AvaloniaSample/GlobalUsings.cs
+++ b/Stellar.AvaloniaSample/GlobalUsings.cs
@@ -2,4 +2,5 @@ global using System.Reactive;
 global using System.Reactive.Disposables;
 global using System.Reactive.Linq;
 global using ReactiveUI;
+global using ReactiveUI.Reactive;
 global using ReactiveUI.SourceGenerators;

--- a/Stellar.AvaloniaSample/Program.cs
+++ b/Stellar.AvaloniaSample/Program.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Avalonia;
-using Avalonia.ReactiveUI;
 using Stellar.Avalonia;
 
 namespace Stellar.AvaloniaSample;
@@ -21,9 +20,8 @@ public static class Program
             .UsePlatformDetect()
             .WithInterFont()
             .LogToTrace()
-            .UseStellarComponents()
 #if DEBUG
             .EnableHotReload()
 #endif
-            .UseReactiveUI();
+            .UseStellarComponents();
 }

--- a/Stellar.AvaloniaSample/Stellar.AvaloniaSample.csproj
+++ b/Stellar.AvaloniaSample/Stellar.AvaloniaSample.csproj
@@ -18,9 +18,6 @@
     <PackageReference Include="Avalonia.Desktop" />
     <PackageReference Include="Avalonia.Themes.Fluent" />
     <PackageReference Include="Avalonia.Fonts.Inter" />
-    <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" />
-    <PackageReference Include="Avalonia.ReactiveUI" />
     <PackageReference Include="ReactiveUI.SourceGenerators">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Stellar.Blazor/ComponentBase.cs
+++ b/Stellar.Blazor/ComponentBase.cs
@@ -3,7 +3,7 @@ using System.ComponentModel.DataAnnotations;
 using System.Runtime.CompilerServices;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Routing;
-using ReactiveUI.Blazor;
+using ReactiveUI.Reactive.Blazor;
 
 namespace Stellar.Blazor;
 

--- a/Stellar.Blazor/Extensions/BuilderExtensions.cs
+++ b/Stellar.Blazor/Extensions/BuilderExtensions.cs
@@ -1,6 +1,6 @@
 using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
-using ReactiveUI.Builder;
+using ReactiveUI.Reactive.Builder;
 
 namespace Stellar.Blazor;
 

--- a/Stellar.Blazor/GlobalUsings.cs
+++ b/Stellar.Blazor/GlobalUsings.cs
@@ -5,4 +5,5 @@ global using System.Reactive.Disposables;
 global using System.Reactive.Linq;
 global using System.Reactive.Subjects;
 global using ReactiveUI;
-global using ReactiveUI.Blazor;
+global using ReactiveUI.Reactive;
+global using ReactiveUI.Reactive.Blazor;

--- a/Stellar.Blazor/InjectableComponentBase.cs
+++ b/Stellar.Blazor/InjectableComponentBase.cs
@@ -1,7 +1,7 @@
 ﻿using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using Microsoft.AspNetCore.Components;
-using ReactiveUI.Blazor;
+using ReactiveUI.Reactive.Blazor;
 
 namespace Stellar.Blazor;
 

--- a/Stellar.Blazor/LayoutComponentBase.cs
+++ b/Stellar.Blazor/LayoutComponentBase.cs
@@ -1,7 +1,7 @@
 ﻿using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using Microsoft.AspNetCore.Components;
-using ReactiveUI.Blazor;
+using ReactiveUI.Reactive.Blazor;
 
 namespace Stellar.Blazor;
 

--- a/Stellar.Blazor/Stellar.Blazor.csproj
+++ b/Stellar.Blazor/Stellar.Blazor.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.AutoActivation" />
-    <PackageReference Include="ReactiveUI.Blazor" />
+    <PackageReference Include="ReactiveUI.Blazor.Reactive" />
   </ItemGroup>
 
   	<ItemGroup>

--- a/Stellar.BlazorSample/GlobalUsings.cs
+++ b/Stellar.BlazorSample/GlobalUsings.cs
@@ -2,4 +2,5 @@
 global using System.Reactive.Disposables;
 global using System.Reactive.Linq;
 global using ReactiveUI;
+global using ReactiveUI.Reactive;
 global using ReactiveUI.SourceGenerators;

--- a/Stellar.Maui.PopUp/Extensions/PopupNavigationObservableExtensions.cs
+++ b/Stellar.Maui.PopUp/Extensions/PopupNavigationObservableExtensions.cs
@@ -4,6 +4,7 @@ using System.Reactive.Linq;
 using Mopups.Pages;
 using Mopups.Services;
 using ReactiveUI;
+using ReactiveUI.Reactive;
 using Stellar.Exceptions;
 using Stellar.Maui.Exceptions;
 using static Stellar.Maui.NavigationObservableExtensions;

--- a/Stellar.Maui.PopUp/ReactivePopupPage.cs
+++ b/Stellar.Maui.PopUp/ReactivePopupPage.cs
@@ -1,5 +1,6 @@
 using Mopups.Pages;
 using ReactiveUI;
+using ReactiveUI.Reactive;
 
 namespace Stellar.Maui.Pages;
 

--- a/Stellar.Maui.PopUp/Stellar.Maui.PopUp.csproj
+++ b/Stellar.Maui.PopUp/Stellar.Maui.PopUp.csproj
@@ -33,7 +33,7 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.Maui.Controls" />
-        <PackageReference Include="ReactiveUI" />
+        <PackageReference Include="ReactiveUI.Reactive" />
         <PackageReference Include="Mopups" />
     </ItemGroup>
     <ItemGroup>

--- a/Stellar.Maui/Extensions/MauiAppBuilderExtensions.cs
+++ b/Stellar.Maui/Extensions/MauiAppBuilderExtensions.cs
@@ -1,7 +1,7 @@
 using System.Reflection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using ReactiveUI.Builder;
-using ReactiveUI.Maui;
+using ReactiveUI.Reactive.Builder;
+using ReactiveUI.Reactive.Maui;
 using Splat;
 
 namespace Stellar.Maui;

--- a/Stellar.Maui/Extensions/VisualElementExtensions.cs
+++ b/Stellar.Maui/Extensions/VisualElementExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using System.Runtime.CompilerServices;
-using DynamicData.Diagnostics;
 using Stellar.Exceptions;
 using Stellar.ViewModel;
 

--- a/Stellar.Maui/GlobalUsings.cs
+++ b/Stellar.Maui/GlobalUsings.cs
@@ -10,4 +10,10 @@ global using System.Reactive.Disposables.Fluent;
 global using System.Reactive.Linq;
 global using System.Reactive.Subjects;
 global using ReactiveUI;
+
+// Stellar's own MAUI view wrappers (ReactiveStackLayout, ReactiveGrid, ReactiveViewCell)
+// live in the ReactiveUI.Maui namespaces for historical compatibility; the ReactiveUI 24
+// platform types now come from ReactiveUI.Reactive.Maui.
 global using ReactiveUI.Maui;
+global using ReactiveUI.Reactive;
+global using ReactiveUI.Reactive.Maui;

--- a/Stellar.Maui/Stellar.Maui.csproj
+++ b/Stellar.Maui/Stellar.Maui.csproj
@@ -33,7 +33,7 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.Maui.Controls" />
-        <PackageReference Include="ReactiveUI.Maui" />
+        <PackageReference Include="ReactiveUI.Maui.Reactive" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\Stellar\Stellar.csproj" />

--- a/Stellar.Maui/Views/ReactiveViewCell.cs
+++ b/Stellar.Maui/Views/ReactiveViewCell.cs
@@ -1,0 +1,59 @@
+// StellarUI continues to support ListView for as long as .NET MAUI ships it. MAUI marks
+// ListView and its cell types obsolete in favour of CollectionView, but removing this
+// surface would break every consumer still using it, so the deprecation is suppressed here
+// rather than propagated. Revisit when MAUI actually removes the types.
+#pragma warning disable CS0618 // Type or member is obsolete
+
+// ReactiveUI.Maui shipped a ReactiveViewCell up to version 23; ReactiveUI 24 dropped it,
+// so Stellar provides its own. It lives in this namespace alongside ReactiveGrid and
+// ReactiveStackLayout, which Stellar has always supplied itself.
+namespace ReactiveUI.Maui.Views;
+
+/// <summary>
+/// This is a <see cref="ViewCell"/> that is also an <see cref="IViewFor{T}"/>.
+/// </summary>
+/// <typeparam name="TViewModel">The type of the view model.</typeparam>
+/// <seealso cref="Microsoft.Maui.Controls.ViewCell" />
+/// <seealso cref="ReactiveUI.IViewFor{TViewModel}" />
+public class ReactiveViewCell<TViewModel> : ViewCell, IViewFor<TViewModel>
+    where TViewModel : class
+{
+    /// <summary>
+    /// The view model bindable property.
+    /// </summary>
+    public static readonly BindableProperty ViewModelProperty = BindableProperty.Create(
+        nameof(ViewModel),
+        typeof(TViewModel),
+        typeof(ReactiveViewCell<TViewModel>),
+        default(TViewModel),
+        BindingMode.OneWay,
+        propertyChanged: OnViewModelChanged);
+
+    /// <summary>
+    /// Gets or sets the ViewModel to display.
+    /// </summary>
+    public TViewModel? ViewModel
+    {
+        get => (TViewModel)GetValue(ViewModelProperty);
+        set => SetValue(ViewModelProperty, value);
+    }
+
+    /// <inheritdoc/>
+    object? IViewFor.ViewModel
+    {
+        get => ViewModel;
+        set => ViewModel = value as TViewModel;
+    }
+
+    /// <inheritdoc/>
+    protected override void OnBindingContextChanged()
+    {
+        base.OnBindingContextChanged();
+        ViewModel = BindingContext as TViewModel;
+    }
+
+    private static void OnViewModelChanged(BindableObject bindableObject, object oldValue, object newValue)
+    {
+        bindableObject.BindingContext = newValue;
+    }
+}

--- a/Stellar.Maui/Views/ViewCellBase.cs
+++ b/Stellar.Maui/Views/ViewCellBase.cs
@@ -5,6 +5,7 @@
 #pragma warning disable CS0618 // Type or member is obsolete
 
 using System.ComponentModel;
+using ReactiveUI.Maui.Views;
 
 namespace Stellar.Maui.Views;
 

--- a/Stellar.MauiBlazorHybridSample/GlobalUsings.cs
+++ b/Stellar.MauiBlazorHybridSample/GlobalUsings.cs
@@ -2,6 +2,7 @@
 global using System.Reactive.Disposables;
 global using System.Reactive.Linq;
 global using ReactiveUI;
+global using ReactiveUI.Reactive;
 global using ReactiveUI.SourceGenerators;
 global using Stellar.Maui;
 global using Stellar.Maui.Pages;

--- a/Stellar.MauiSample/GlobalUsings.cs
+++ b/Stellar.MauiSample/GlobalUsings.cs
@@ -3,6 +3,7 @@ global using System.Reactive.Disposables;
 global using System.Reactive.Linq;
 global using CommunityToolkit.Maui.Markup;
 global using ReactiveUI;
+global using ReactiveUI.Reactive;
 global using ReactiveUI.SourceGenerators;
 global using Stellar.Maui;
 global using Stellar.Maui.Pages;

--- a/Stellar.MauiSample/Stellar.MauiSample.csproj
+++ b/Stellar.MauiSample/Stellar.MauiSample.csproj
@@ -72,7 +72,7 @@
         <PackageReference Include="Microsoft.Extensions.Logging.Debug" />
         <PackageReference Include="ReactiveMarbles.ObservableEvents.SourceGenerator" />
         <!-- This should be cleaned-up or replaced later on -->
-        <PackageReference Include="ReactiveUI.Maui" />
+        <PackageReference Include="ReactiveUI.Maui.Reactive" />
         <PackageReference Include="ReactiveUI.SourceGenerators">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Stellar.UnitTests/Usings.cs
+++ b/Stellar.UnitTests/Usings.cs
@@ -1,1 +1,2 @@
-﻿global using Xunit;
+﻿global using ReactiveUI.Reactive;
+global using Xunit;

--- a/Stellar.Uno/Extensions/BuilderExtensions.cs
+++ b/Stellar.Uno/Extensions/BuilderExtensions.cs
@@ -1,0 +1,51 @@
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.UI.Dispatching;
+using ReactiveUI.Reactive.Builder;
+
+namespace Stellar.Uno;
+
+public static class BuilderExtensions
+{
+    public static IServiceCollection UseStellarComponents<TStellarAssembly>(this IServiceCollection services)
+    {
+        UseStellarComponents(services);
+
+        services.ConfigureStellarComponents(typeof(TStellarAssembly).GetTypeInfo().Assembly);
+
+        return services;
+    }
+
+    /// <summary>
+    /// Registers Stellar's Uno Platform services. Must be called from the UI thread
+    /// (e.g. in <c>Application.OnLaunched</c>) so the UI thread's
+    /// <see cref="DispatcherQueue"/> can be captured for the main-thread scheduler.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The same service collection, for chaining.</returns>
+    public static IServiceCollection UseStellarComponents(this IServiceCollection services)
+    {
+        var dispatcherQueue = DispatcherQueue.GetForCurrentThread()
+            ?? throw new InvalidOperationException(
+                "UseStellarComponents must be called from the UI thread so the DispatcherQueue can be captured.");
+
+        // There is no ReactiveUI 24-compatible Uno platform package, so the activation
+        // fetcher and schedulers are registered here directly, mirroring Stellar.Avalonia.
+        RxAppBuilder
+            .CreateReactiveUIBuilder()
+            .WithRegistration(
+                static resolver => resolver.RegisterConstant<IActivationForViewFetcher>(new UnoActivationForViewFetcher()))
+            .WithMainThreadScheduler(new UnoScheduler(dispatcherQueue))
+            .WithTaskPoolScheduler(Schedulers.ShortTermThreadPoolScheduler)
+            .Build();
+
+        return services;
+    }
+
+    public static IServiceCollection EnableHotReload(this IServiceCollection services)
+    {
+        HotReloadService.HotReloadAware = true;
+
+        return services;
+    }
+}

--- a/Stellar.Uno/GlobalUsings.cs
+++ b/Stellar.Uno/GlobalUsings.cs
@@ -1,0 +1,8 @@
+global using System;
+global using System.Reactive;
+global using System.Reactive.Concurrency;
+global using System.Reactive.Disposables;
+global using System.Reactive.Linq;
+global using System.Reactive.Subjects;
+global using ReactiveUI;
+global using ReactiveUI.Reactive;

--- a/Stellar.Uno/HotReloadService.cs
+++ b/Stellar.Uno/HotReloadService.cs
@@ -1,0 +1,21 @@
+﻿#pragma warning disable CS8632 // The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
+[assembly: System.Reflection.Metadata.MetadataUpdateHandler(typeof(Stellar.Uno.HotReloadService))]
+
+namespace Stellar.Uno;
+
+public static class HotReloadService
+{
+    public static bool HotReloadAware { get; set; }
+
+    public static event Action<Type[]?>? UpdateApplicationEvent;
+
+    internal static void ClearCache(Type[]? types)
+    {
+    }
+
+    internal static void UpdateApplication(Type[]? types)
+    {
+        UpdateApplicationEvent?.Invoke(types);
+    }
+}
+#pragma warning restore CS8632 // The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.

--- a/Stellar.Uno/PageBase.cs
+++ b/Stellar.Uno/PageBase.cs
@@ -1,0 +1,117 @@
+using System.ComponentModel;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Navigation;
+
+namespace Stellar.Uno;
+
+// Implements IViewFor directly: there is no ReactiveUI 24-compatible Uno platform
+// package to supply a ReactivePage base class, so Stellar provides the ViewModel
+// dependency property and DataContext syncing itself.
+public abstract class PageBase<TViewModel> : Page, IStellarView<TViewModel>
+    where TViewModel : class
+{
+    public static readonly DependencyProperty ViewModelProperty = DependencyProperty.Register(
+        nameof(ViewModel),
+        typeof(TViewModel),
+        typeof(PageBase<TViewModel>),
+        new PropertyMetadata(null));
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public ViewManager<TViewModel> ViewManager { get; } = new UnoViewManager<TViewModel>();
+
+    public TViewModel? ViewModel
+    {
+        get => (TViewModel?)GetValue(ViewModelProperty);
+        set => SetValue(ViewModelProperty, value);
+    }
+
+    object? IViewFor.ViewModel
+    {
+        get => ViewModel;
+        set => ViewModel = value as TViewModel;
+    }
+
+    public IObservable<Unit> PageInitialized => ViewManager.Initialized;
+
+    public IObservable<Unit> Activated => ViewManager.Activated;
+
+    public IObservable<Unit> Deactivated => ViewManager.Deactivated;
+
+    public IObservable<Unit> IsAppearing => ViewManager.IsAppearing;
+
+    public IObservable<Unit> IsDisappearing => ViewManager.IsDisappearing;
+
+    public IObservable<Unit> NavigatedTo => ViewManager.NavigatedTo;
+
+    public IObservable<Unit> NavigatedFrom => ViewManager.NavigatedFrom;
+
+    public IObservable<Unit> Disposed => ViewManager.Disposed;
+
+    public IObservable<LifecycleEvent> LifecycleEvents => ViewManager.LifecycleEvents;
+
+    protected PageBase()
+        : this(manuallyInitialize: true)
+    {
+    }
+
+    protected PageBase(
+        TViewModel? viewModel = null,
+        bool maintain = false,
+        bool delayBindingRegistrationUntilAttached = false,
+        bool manuallyInitialize = true)
+    {
+        Loaded += HandleLoaded;
+        Unloaded += HandleUnloaded;
+        DataContextChanged += HandleDataContextChanged;
+        RegisterPropertyChangedCallback(
+            ViewModelProperty,
+            (_, _) => ViewManager.PropertyChanged(this, nameof(ViewModel)));
+
+        if (!manuallyInitialize)
+        {
+            this.InitializeStellarComponent(viewModel, maintain, delayBindingRegistrationUntilAttached);
+        }
+    }
+
+    public virtual void Initialize()
+    {
+    }
+
+    public abstract void SetupUserInterface();
+
+    public abstract void Bind(WeakCompositeDisposable disposables);
+
+    protected override void OnNavigatedTo(NavigationEventArgs e)
+    {
+        base.OnNavigatedTo(e);
+
+        ViewManager.OnNavigating(this, NavigationEvent.NavigatedTo);
+    }
+
+    protected override void OnNavigatedFrom(NavigationEventArgs e)
+    {
+        ViewManager.OnNavigating(this, NavigationEvent.NavigatedFrom);
+
+        base.OnNavigatedFrom(e);
+    }
+
+    private void HandleLoaded(object sender, RoutedEventArgs e)
+    {
+        ViewManager.HandleActivated(this);
+
+        ViewManager.OnLifecycle(this, LifecycleEvent.IsAppearing);
+    }
+
+    private void HandleUnloaded(object sender, RoutedEventArgs e)
+    {
+        ViewManager.OnLifecycle(this, LifecycleEvent.IsDisappearing);
+
+        ViewManager.HandleDeactivated(this);
+    }
+
+    private void HandleDataContextChanged(FrameworkElement sender, DataContextChangedEventArgs args)
+    {
+        ViewModel = args.NewValue as TViewModel;
+    }
+}

--- a/Stellar.Uno/Stellar.Uno.csproj
+++ b/Stellar.Uno/Stellar.Uno.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <SingleProject>true</SingleProject>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <PackageId>StellarUI.Uno</PackageId>
+    <Title>Stellar UI - Uno Platform</Title>
+    <Authors>Eight-Bot</Authors>
+    <Copyright>Eight-Bot 2026</Copyright>
+    <PackageLicenseUrl>https://github.com/TheEightBot/StellarUI/blob/main/LICENSE</PackageLicenseUrl>
+    <RepositoryUrl>https://github.com/TheEightBot/StellarUI</RepositoryUrl>
+    <PackageTags>Uno Platform;MVVM;Reactive UI;Reactive Extensions;Eight-Bot</PackageTags>
+  </PropertyGroup>
+  <ItemGroup>
+    <!-- There is no ReactiveUI 24-compatible Uno platform package (ReactiveUI.Uno
+         stopped at 23, ReactiveUI.Uno.WinUI at 20), so this project registers its
+         own activation fetcher and DispatcherQueue scheduler, the same way
+         Stellar.Avalonia does. Targets the Uno (non-Windows) heads; the WinAppSDK
+         head of an Uno app should use StellarUI.WinUI instead. -->
+    <PackageReference Include="Uno.WinUI" />
+    <PackageReference Include="ReactiveUI.Reactive" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Stellar\Stellar.csproj" />
+  </ItemGroup>
+</Project>

--- a/Stellar.Uno/UnoActivationForViewFetcher.cs
+++ b/Stellar.Uno/UnoActivationForViewFetcher.cs
@@ -1,0 +1,37 @@
+using Microsoft.UI.Xaml;
+
+namespace Stellar.Uno;
+
+/// <summary>
+/// Determines when Uno Platform views are activated and deactivated so that
+/// <c>WhenActivated</c> works for them. There is no ReactiveUI 24-compatible Uno
+/// platform package, so Stellar provides this itself. Views follow
+/// <see cref="FrameworkElement.Loaded"/> / <see cref="FrameworkElement.Unloaded"/>.
+/// </summary>
+public sealed class UnoActivationForViewFetcher : IActivationForViewFetcher
+{
+    public int GetAffinityForView(Type view) =>
+        typeof(FrameworkElement).IsAssignableFrom(view) ? 10 : 0;
+
+    public IObservable<bool> GetActivationForView(IActivatableView view)
+    {
+        if (view is not FrameworkElement element)
+        {
+            return Observable.Return(false);
+        }
+
+        var loaded = Observable
+            .FromEventPattern<RoutedEventHandler, RoutedEventArgs>(
+                handler => element.Loaded += handler,
+                handler => element.Loaded -= handler)
+            .Select(static _ => true);
+
+        var unloaded = Observable
+            .FromEventPattern<RoutedEventHandler, RoutedEventArgs>(
+                handler => element.Unloaded += handler,
+                handler => element.Unloaded -= handler)
+            .Select(static _ => false);
+
+        return loaded.Merge(unloaded).DistinctUntilChanged();
+    }
+}

--- a/Stellar.Uno/UnoScheduler.cs
+++ b/Stellar.Uno/UnoScheduler.cs
@@ -1,0 +1,80 @@
+using Microsoft.UI.Dispatching;
+
+namespace Stellar.Uno;
+
+/// <summary>
+/// An <see cref="IScheduler"/> that schedules work onto an Uno Platform UI thread via its
+/// <see cref="DispatcherQueue"/>. There is no ReactiveUI 24-compatible Uno platform
+/// package, so Stellar provides this itself. Work scheduled with no due time from the UI
+/// thread runs inline.
+/// </summary>
+public sealed class UnoScheduler : IScheduler
+{
+    private readonly DispatcherQueue _dispatcherQueue;
+
+    public UnoScheduler(DispatcherQueue dispatcherQueue)
+    {
+        ArgumentNullException.ThrowIfNull(dispatcherQueue);
+
+        _dispatcherQueue = dispatcherQueue;
+    }
+
+    public DateTimeOffset Now => DateTimeOffset.Now;
+
+    public IDisposable Schedule<TState>(TState state, Func<IScheduler, TState, IDisposable> action)
+    {
+        var innerDisp = new SingleAssignmentDisposable();
+
+        if (_dispatcherQueue.HasThreadAccess)
+        {
+            innerDisp.Disposable = action(this, state);
+
+            return innerDisp;
+        }
+
+        _dispatcherQueue.TryEnqueue(
+            () =>
+            {
+                if (!innerDisp.IsDisposed)
+                {
+                    innerDisp.Disposable = action(this, state);
+                }
+            });
+
+        return innerDisp;
+    }
+
+    public IDisposable Schedule<TState>(TState state, TimeSpan dueTime, Func<IScheduler, TState, IDisposable> action)
+    {
+        if (dueTime <= TimeSpan.Zero)
+        {
+            return Schedule(state, action);
+        }
+
+        var innerDisp = new SingleAssignmentDisposable();
+        var timer = _dispatcherQueue.CreateTimer();
+        timer.Interval = dueTime;
+        timer.IsRepeating = false;
+        timer.Tick += (_, _) =>
+        {
+            if (!innerDisp.IsDisposed)
+            {
+                innerDisp.Disposable = action(this, state);
+            }
+        };
+        timer.Start();
+
+        return new CompositeDisposable(
+            Disposable.Create(timer, static t => t.Stop()),
+            innerDisp);
+    }
+
+    public IDisposable Schedule<TState>(TState state, DateTimeOffset dueTime, Func<IScheduler, TState, IDisposable> action)
+    {
+        var relative = dueTime - Now;
+
+        return relative <= TimeSpan.Zero
+            ? Schedule(state, action)
+            : Schedule(state, relative, action);
+    }
+}

--- a/Stellar.Uno/UnoViewManager.cs
+++ b/Stellar.Uno/UnoViewManager.cs
@@ -1,0 +1,66 @@
+using Microsoft.UI.Xaml;
+
+namespace Stellar.Uno;
+
+public class UnoViewManager<TViewModel> : ViewManager<TViewModel>
+    where TViewModel : class
+{
+    // Null whenever no view is activated, which HandleDeactivated relies on.
+    private IStellarView<TViewModel>? _view;
+
+    public override void HandleActivated(IStellarView<TViewModel> view)
+    {
+        base.HandleActivated(view);
+
+        if (HotReloadService.HotReloadAware)
+        {
+            _view = view;
+            HotReloadService.UpdateApplicationEvent -= HandleHotReload;
+            HotReloadService.UpdateApplicationEvent += HandleHotReload;
+        }
+    }
+
+    public override void HandleDeactivated(IStellarView<TViewModel> view)
+    {
+        if (HotReloadService.HotReloadAware)
+        {
+            _view = null;
+            HotReloadService.UpdateApplicationEvent -= HandleHotReload;
+        }
+
+        base.HandleDeactivated(view);
+    }
+
+#pragma warning disable CS8632 // The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
+    private void HandleHotReload(Type[]? updatedTypes)
+#pragma warning restore CS8632 // The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
+    {
+        if (_view is not FrameworkElement fe)
+        {
+            return;
+        }
+
+        fe.DispatcherQueue.TryEnqueue(
+            () =>
+            {
+                var view = _view;
+
+                if (view is null)
+                {
+                    return;
+                }
+
+                var maintainStatus = view.ViewManager.Maintain;
+
+                view.ViewManager.Maintain = false;
+
+                view.ViewManager.UnregisterBindings(view);
+
+                view.ViewManager.Maintain = maintainStatus;
+
+                view.SetupUserInterface();
+
+                view.ViewManager.RegisterBindings(view);
+            });
+    }
+}

--- a/Stellar.Uno/UserControlBase.cs
+++ b/Stellar.Uno/UserControlBase.cs
@@ -1,0 +1,94 @@
+using System.ComponentModel;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Stellar.Uno;
+
+// Implements IViewFor directly: there is no ReactiveUI 24-compatible Uno platform
+// package to supply a ReactiveUserControl base class, so Stellar provides the ViewModel
+// dependency property and DataContext syncing itself.
+public abstract class UserControlBase<TViewModel> : UserControl, IStellarView<TViewModel>
+    where TViewModel : class
+{
+    public static readonly DependencyProperty ViewModelProperty = DependencyProperty.Register(
+        nameof(ViewModel),
+        typeof(TViewModel),
+        typeof(UserControlBase<TViewModel>),
+        new PropertyMetadata(null));
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public ViewManager<TViewModel> ViewManager { get; } = new UnoViewManager<TViewModel>();
+
+    public TViewModel? ViewModel
+    {
+        get => (TViewModel?)GetValue(ViewModelProperty);
+        set => SetValue(ViewModelProperty, value);
+    }
+
+    object? IViewFor.ViewModel
+    {
+        get => ViewModel;
+        set => ViewModel = value as TViewModel;
+    }
+
+    public IObservable<Unit> UserControlInitialized => ViewManager.Initialized;
+
+    public IObservable<Unit> Activated => ViewManager.Activated;
+
+    public IObservable<Unit> Deactivated => ViewManager.Deactivated;
+
+    public IObservable<Unit> Disposed => ViewManager.Disposed;
+
+    public IObservable<LifecycleEvent> LifecycleEvents => ViewManager.LifecycleEvents;
+
+    protected UserControlBase()
+        : this(manuallyInitialize: true)
+    {
+    }
+
+    protected UserControlBase(
+        TViewModel? viewModel = null,
+        bool maintain = false,
+        bool delayBindingRegistrationUntilAttached = false,
+        bool manuallyInitialize = true)
+    {
+        Loaded += HandleLoaded;
+        Unloaded += HandleUnloaded;
+        DataContextChanged += HandleDataContextChanged;
+        RegisterPropertyChangedCallback(
+            ViewModelProperty,
+            (_, _) => ViewManager.PropertyChanged(this, nameof(ViewModel)));
+
+        if (!manuallyInitialize)
+        {
+            this.InitializeStellarComponent(viewModel, maintain, delayBindingRegistrationUntilAttached);
+        }
+    }
+
+    public virtual void Initialize()
+    {
+    }
+
+    public abstract void SetupUserInterface();
+
+    public abstract void Bind(WeakCompositeDisposable disposables);
+
+    private void HandleLoaded(object sender, RoutedEventArgs e)
+    {
+        ViewManager.HandleActivated(this);
+
+        ViewManager.OnLifecycle(this, LifecycleEvent.IsAppearing);
+    }
+
+    private void HandleUnloaded(object sender, RoutedEventArgs e)
+    {
+        ViewManager.OnLifecycle(this, LifecycleEvent.IsDisappearing);
+
+        ViewManager.HandleDeactivated(this);
+    }
+
+    private void HandleDataContextChanged(FrameworkElement sender, DataContextChangedEventArgs args)
+    {
+        ViewModel = args.NewValue as TViewModel;
+    }
+}

--- a/Stellar.WinUI/Extensions/BuilderExtensions.cs
+++ b/Stellar.WinUI/Extensions/BuilderExtensions.cs
@@ -1,0 +1,39 @@
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using ReactiveUI.Builder;
+using ReactiveUI.Reactive.Builder;
+
+namespace Stellar.WinUI;
+
+public static class BuilderExtensions
+{
+    public static IServiceCollection UseStellarComponents<TStellarAssembly>(this IServiceCollection services)
+    {
+        UseStellarComponents(services);
+
+        services.ConfigureStellarComponents(typeof(TStellarAssembly).GetTypeInfo().Assembly);
+
+        return services;
+    }
+
+    public static IServiceCollection UseStellarComponents(this IServiceCollection services)
+    {
+        // WithWinUI registers the WinUI platform services (activation fetcher,
+        // main-thread scheduler, binding hooks) that ReactiveUI's old
+        // InitializeReactiveUI selected.
+        RxAppBuilder
+            .CreateReactiveUIBuilder()
+            .WithWinUI()
+            .WithTaskPoolScheduler(Schedulers.ShortTermThreadPoolScheduler)
+            .Build();
+
+        return services;
+    }
+
+    public static IServiceCollection EnableHotReload(this IServiceCollection services)
+    {
+        HotReloadService.HotReloadAware = true;
+
+        return services;
+    }
+}

--- a/Stellar.WinUI/GlobalUsings.cs
+++ b/Stellar.WinUI/GlobalUsings.cs
@@ -1,0 +1,8 @@
+global using System;
+global using System.Reactive;
+global using System.Reactive.Concurrency;
+global using System.Reactive.Disposables;
+global using System.Reactive.Linq;
+global using System.Reactive.Subjects;
+global using ReactiveUI;
+global using ReactiveUI.Reactive;

--- a/Stellar.WinUI/HotReloadService.cs
+++ b/Stellar.WinUI/HotReloadService.cs
@@ -1,0 +1,21 @@
+﻿#pragma warning disable CS8632 // The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
+[assembly: System.Reflection.Metadata.MetadataUpdateHandler(typeof(Stellar.WinUI.HotReloadService))]
+
+namespace Stellar.WinUI;
+
+public static class HotReloadService
+{
+    public static bool HotReloadAware { get; set; }
+
+    public static event Action<Type[]?>? UpdateApplicationEvent;
+
+    internal static void ClearCache(Type[]? types)
+    {
+    }
+
+    internal static void UpdateApplication(Type[]? types)
+    {
+        UpdateApplicationEvent?.Invoke(types);
+    }
+}
+#pragma warning restore CS8632 // The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.

--- a/Stellar.WinUI/PageBase.cs
+++ b/Stellar.WinUI/PageBase.cs
@@ -1,0 +1,92 @@
+using System.ComponentModel;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Navigation;
+
+namespace Stellar.WinUI;
+
+// ReactivePage supplies the ViewModel dependency property and IViewFor plumbing; Stellar
+// layers its ViewManager lifecycle on top. WinUI has no all-property change virtual, so
+// ViewModel changes are forwarded through RegisterPropertyChangedCallback instead.
+public abstract class PageBase<TViewModel> : ReactivePage<TViewModel>, IStellarView<TViewModel>
+    where TViewModel : class
+{
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public ViewManager<TViewModel> ViewManager { get; } = new WinUIViewManager<TViewModel>();
+
+    public IObservable<Unit> PageInitialized => ViewManager.Initialized;
+
+    public IObservable<Unit> Activated => ViewManager.Activated;
+
+    public IObservable<Unit> Deactivated => ViewManager.Deactivated;
+
+    public IObservable<Unit> IsAppearing => ViewManager.IsAppearing;
+
+    public IObservable<Unit> IsDisappearing => ViewManager.IsDisappearing;
+
+    public IObservable<Unit> NavigatedTo => ViewManager.NavigatedTo;
+
+    public IObservable<Unit> NavigatedFrom => ViewManager.NavigatedFrom;
+
+    public IObservable<Unit> Disposed => ViewManager.Disposed;
+
+    public IObservable<LifecycleEvent> LifecycleEvents => ViewManager.LifecycleEvents;
+
+    protected PageBase()
+        : this(manuallyInitialize: true)
+    {
+    }
+
+    protected PageBase(
+        TViewModel? viewModel = null,
+        bool maintain = false,
+        bool delayBindingRegistrationUntilAttached = false,
+        bool manuallyInitialize = true)
+    {
+        Loaded += HandleLoaded;
+        Unloaded += HandleUnloaded;
+        RegisterPropertyChangedCallback(
+            ViewModelProperty,
+            (_, _) => ViewManager.PropertyChanged(this, nameof(ViewModel)));
+
+        if (!manuallyInitialize)
+        {
+            this.InitializeStellarComponent(viewModel, maintain, delayBindingRegistrationUntilAttached);
+        }
+    }
+
+    public virtual void Initialize()
+    {
+    }
+
+    public abstract void SetupUserInterface();
+
+    public abstract void Bind(WeakCompositeDisposable disposables);
+
+    protected override void OnNavigatedTo(NavigationEventArgs e)
+    {
+        base.OnNavigatedTo(e);
+
+        ViewManager.OnNavigating(this, NavigationEvent.NavigatedTo);
+    }
+
+    protected override void OnNavigatedFrom(NavigationEventArgs e)
+    {
+        ViewManager.OnNavigating(this, NavigationEvent.NavigatedFrom);
+
+        base.OnNavigatedFrom(e);
+    }
+
+    private void HandleLoaded(object sender, RoutedEventArgs e)
+    {
+        ViewManager.HandleActivated(this);
+
+        ViewManager.OnLifecycle(this, LifecycleEvent.IsAppearing);
+    }
+
+    private void HandleUnloaded(object sender, RoutedEventArgs e)
+    {
+        ViewManager.OnLifecycle(this, LifecycleEvent.IsDisappearing);
+
+        ViewManager.HandleDeactivated(this);
+    }
+}

--- a/Stellar.WinUI/Stellar.WinUI.csproj
+++ b/Stellar.WinUI/Stellar.WinUI.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows10.0.19041.0</TargetFramework>
+    <UseWinUI>true</UseWinUI>
+    <!-- Allows compiling (not running) this Windows-only library on macOS/Linux dev
+         machines and CI. Harmless when building on Windows. The MRT Core / MSIX
+         tooling shells out to MakePri.exe, a Windows executable, so it is disabled
+         when the build host is not Windows; this library carries no PRI resources,
+         and Windows builds are unaffected. -->
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+    <EnableCoreMrtTooling Condition="!$([MSBuild]::IsOSPlatform('windows'))">false</EnableCoreMrtTooling>
+    <EnableMsixTooling Condition="!$([MSBuild]::IsOSPlatform('windows'))">false</EnableMsixTooling>
+    <AppxGeneratePriEnabled Condition="!$([MSBuild]::IsOSPlatform('windows'))">false</AppxGeneratePriEnabled>
+    <SingleProject>true</SingleProject>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <PackageId>StellarUI.WinUI</PackageId>
+    <Title>Stellar UI - WinUI 3</Title>
+    <Authors>Eight-Bot</Authors>
+    <Copyright>Eight-Bot 2026</Copyright>
+    <PackageLicenseUrl>https://github.com/TheEightBot/StellarUI/blob/main/LICENSE</PackageLicenseUrl>
+    <RepositoryUrl>https://github.com/TheEightBot/StellarUI</RepositoryUrl>
+    <PackageTags>WinUI;Windows App SDK;MVVM;Reactive UI;Reactive Extensions;Eight-Bot</PackageTags>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.WindowsAppSDK" />
+    <PackageReference Include="ReactiveUI.WinUI.Reactive" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Stellar\Stellar.csproj" />
+  </ItemGroup>
+</Project>

--- a/Stellar.WinUI/UserControlBase.cs
+++ b/Stellar.WinUI/UserControlBase.cs
@@ -1,0 +1,69 @@
+using System.ComponentModel;
+using Microsoft.UI.Xaml;
+
+namespace Stellar.WinUI;
+
+// ReactiveUserControl supplies the ViewModel dependency property and IViewFor plumbing;
+// Stellar layers its ViewManager lifecycle on top. WinUI has no all-property change
+// virtual, so ViewModel changes are forwarded through RegisterPropertyChangedCallback.
+public abstract class UserControlBase<TViewModel> : ReactiveUserControl<TViewModel>, IStellarView<TViewModel>
+    where TViewModel : class
+{
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public ViewManager<TViewModel> ViewManager { get; } = new WinUIViewManager<TViewModel>();
+
+    public IObservable<Unit> UserControlInitialized => ViewManager.Initialized;
+
+    public IObservable<Unit> Activated => ViewManager.Activated;
+
+    public IObservable<Unit> Deactivated => ViewManager.Deactivated;
+
+    public IObservable<Unit> Disposed => ViewManager.Disposed;
+
+    public IObservable<LifecycleEvent> LifecycleEvents => ViewManager.LifecycleEvents;
+
+    protected UserControlBase()
+        : this(manuallyInitialize: true)
+    {
+    }
+
+    protected UserControlBase(
+        TViewModel? viewModel = null,
+        bool maintain = false,
+        bool delayBindingRegistrationUntilAttached = false,
+        bool manuallyInitialize = true)
+    {
+        Loaded += HandleLoaded;
+        Unloaded += HandleUnloaded;
+        RegisterPropertyChangedCallback(
+            ViewModelProperty,
+            (_, _) => ViewManager.PropertyChanged(this, nameof(ViewModel)));
+
+        if (!manuallyInitialize)
+        {
+            this.InitializeStellarComponent(viewModel, maintain, delayBindingRegistrationUntilAttached);
+        }
+    }
+
+    public virtual void Initialize()
+    {
+    }
+
+    public abstract void SetupUserInterface();
+
+    public abstract void Bind(WeakCompositeDisposable disposables);
+
+    private void HandleLoaded(object sender, RoutedEventArgs e)
+    {
+        ViewManager.HandleActivated(this);
+
+        ViewManager.OnLifecycle(this, LifecycleEvent.IsAppearing);
+    }
+
+    private void HandleUnloaded(object sender, RoutedEventArgs e)
+    {
+        ViewManager.OnLifecycle(this, LifecycleEvent.IsDisappearing);
+
+        ViewManager.HandleDeactivated(this);
+    }
+}

--- a/Stellar.WinUI/WinUIViewManager.cs
+++ b/Stellar.WinUI/WinUIViewManager.cs
@@ -1,0 +1,66 @@
+using Microsoft.UI.Xaml;
+
+namespace Stellar.WinUI;
+
+public class WinUIViewManager<TViewModel> : ViewManager<TViewModel>
+    where TViewModel : class
+{
+    // Null whenever no view is activated, which HandleDeactivated relies on.
+    private IStellarView<TViewModel>? _view;
+
+    public override void HandleActivated(IStellarView<TViewModel> view)
+    {
+        base.HandleActivated(view);
+
+        if (HotReloadService.HotReloadAware)
+        {
+            _view = view;
+            HotReloadService.UpdateApplicationEvent -= HandleHotReload;
+            HotReloadService.UpdateApplicationEvent += HandleHotReload;
+        }
+    }
+
+    public override void HandleDeactivated(IStellarView<TViewModel> view)
+    {
+        if (HotReloadService.HotReloadAware)
+        {
+            _view = null;
+            HotReloadService.UpdateApplicationEvent -= HandleHotReload;
+        }
+
+        base.HandleDeactivated(view);
+    }
+
+#pragma warning disable CS8632 // The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
+    private void HandleHotReload(Type[]? updatedTypes)
+#pragma warning restore CS8632 // The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
+    {
+        if (_view is not FrameworkElement fe)
+        {
+            return;
+        }
+
+        fe.DispatcherQueue.TryEnqueue(
+            () =>
+            {
+                var view = _view;
+
+                if (view is null)
+                {
+                    return;
+                }
+
+                var maintainStatus = view.ViewManager.Maintain;
+
+                view.ViewManager.Maintain = false;
+
+                view.ViewManager.UnregisterBindings(view);
+
+                view.ViewManager.Maintain = maintainStatus;
+
+                view.SetupUserInterface();
+
+                view.ViewManager.RegisterBindings(view);
+            });
+    }
+}

--- a/Stellar.Wpf/Extensions/BuilderExtensions.cs
+++ b/Stellar.Wpf/Extensions/BuilderExtensions.cs
@@ -1,0 +1,37 @@
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using ReactiveUI.Reactive.Builder;
+
+namespace Stellar.Wpf;
+
+public static class BuilderExtensions
+{
+    public static IServiceCollection UseStellarComponents<TStellarAssembly>(this IServiceCollection services)
+    {
+        UseStellarComponents(services);
+
+        services.ConfigureStellarComponents(typeof(TStellarAssembly).GetTypeInfo().Assembly);
+
+        return services;
+    }
+
+    public static IServiceCollection UseStellarComponents(this IServiceCollection services)
+    {
+        // WithWpf registers the WPF platform services (activation fetcher, main-thread
+        // scheduler, binding hooks) that ReactiveUI's old InitializeReactiveUI selected.
+        RxAppBuilder
+            .CreateReactiveUIBuilder()
+            .WithWpf()
+            .WithTaskPoolScheduler(Schedulers.ShortTermThreadPoolScheduler)
+            .Build();
+
+        return services;
+    }
+
+    public static IServiceCollection EnableHotReload(this IServiceCollection services)
+    {
+        HotReloadService.HotReloadAware = true;
+
+        return services;
+    }
+}

--- a/Stellar.Wpf/GlobalUsings.cs
+++ b/Stellar.Wpf/GlobalUsings.cs
@@ -1,0 +1,8 @@
+global using System;
+global using System.Reactive;
+global using System.Reactive.Concurrency;
+global using System.Reactive.Disposables;
+global using System.Reactive.Linq;
+global using System.Reactive.Subjects;
+global using ReactiveUI;
+global using ReactiveUI.Reactive;

--- a/Stellar.Wpf/HotReloadService.cs
+++ b/Stellar.Wpf/HotReloadService.cs
@@ -1,0 +1,21 @@
+﻿#pragma warning disable CS8632 // The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
+[assembly: System.Reflection.Metadata.MetadataUpdateHandler(typeof(Stellar.Wpf.HotReloadService))]
+
+namespace Stellar.Wpf;
+
+public static class HotReloadService
+{
+    public static bool HotReloadAware { get; set; }
+
+    public static event Action<Type[]?>? UpdateApplicationEvent;
+
+    internal static void ClearCache(Type[]? types)
+    {
+    }
+
+    internal static void UpdateApplication(Type[]? types)
+    {
+        UpdateApplicationEvent?.Invoke(types);
+    }
+}
+#pragma warning restore CS8632 // The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.

--- a/Stellar.Wpf/Stellar.Wpf.csproj
+++ b/Stellar.Wpf/Stellar.Wpf.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!-- windows10.0.19041 rather than plain -windows: ReactiveUI.WPF.Reactive only
+         carries its net10.0 build under the windows10 TFM, and plain net10.0-windows
+         (windows7.0) silently falls back to the package's .NET Framework assets. -->
+    <TargetFramework>net10.0-windows10.0.19041.0</TargetFramework>
+    <UseWPF>true</UseWPF>
+    <!-- Allows compiling (not running) this Windows-only library on macOS/Linux dev
+         machines and CI. Harmless when building on Windows. -->
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+    <SingleProject>true</SingleProject>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <PackageId>StellarUI.Wpf</PackageId>
+    <Title>Stellar UI - WPF</Title>
+    <Authors>Eight-Bot</Authors>
+    <Copyright>Eight-Bot 2026</Copyright>
+    <PackageLicenseUrl>https://github.com/TheEightBot/StellarUI/blob/main/LICENSE</PackageLicenseUrl>
+    <RepositoryUrl>https://github.com/TheEightBot/StellarUI</RepositoryUrl>
+    <PackageTags>WPF;MVVM;Reactive UI;Reactive Extensions;Eight-Bot</PackageTags>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="ReactiveUI.WPF.Reactive" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Stellar\Stellar.csproj" />
+  </ItemGroup>
+</Project>

--- a/Stellar.Wpf/UserControlBase.cs
+++ b/Stellar.Wpf/UserControlBase.cs
@@ -1,0 +1,137 @@
+using System.ComponentModel;
+using System.Windows;
+using ReactiveUI.Reactive;
+
+namespace Stellar.Wpf;
+
+// ReactiveUserControl supplies the ViewModel dependency property and IViewFor plumbing;
+// Stellar layers its ViewManager lifecycle on top. WPF has no virtual for Loaded/Unloaded,
+// so the constructor subscribes to the routed events instead.
+public abstract class UserControlBase<TViewModel> : ReactiveUserControl<TViewModel>, IStellarView<TViewModel>
+    where TViewModel : class
+{
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public ViewManager<TViewModel> ViewManager { get; } = new WpfViewManager<TViewModel>();
+
+    public IObservable<Unit> UserControlInitialized => ViewManager.Initialized;
+
+    public IObservable<Unit> Activated => ViewManager.Activated;
+
+    public IObservable<Unit> Deactivated => ViewManager.Deactivated;
+
+    public IObservable<Unit> Disposed => ViewManager.Disposed;
+
+    public IObservable<LifecycleEvent> LifecycleEvents => ViewManager.LifecycleEvents;
+
+    protected UserControlBase()
+        : this(manuallyInitialize: true)
+    {
+    }
+
+    protected UserControlBase(
+        TViewModel? viewModel = null,
+        bool maintain = false,
+        bool delayBindingRegistrationUntilAttached = false,
+        bool manuallyInitialize = true)
+    {
+        Loaded += HandleLoaded;
+        Unloaded += HandleUnloaded;
+
+        if (!manuallyInitialize)
+        {
+            this.InitializeStellarComponent(viewModel, maintain, delayBindingRegistrationUntilAttached);
+        }
+    }
+
+    public virtual void Initialize()
+    {
+    }
+
+    public abstract void SetupUserInterface();
+
+    public abstract void Bind(WeakCompositeDisposable disposables);
+
+    protected override void OnPropertyChanged(DependencyPropertyChangedEventArgs e)
+    {
+        ViewManager.PropertyChanged(this, e.Property.Name);
+
+        base.OnPropertyChanged(e);
+    }
+
+    private void HandleLoaded(object sender, RoutedEventArgs e)
+    {
+        ViewManager.HandleActivated(this);
+
+        ViewManager.OnLifecycle(this, LifecycleEvent.IsAppearing);
+    }
+
+    private void HandleUnloaded(object sender, RoutedEventArgs e)
+    {
+        ViewManager.OnLifecycle(this, LifecycleEvent.IsDisappearing);
+
+        ViewManager.HandleDeactivated(this);
+    }
+}
+
+public abstract class UserControlBase<TViewModel, TDataModel> : ReactiveUserControl<TViewModel>, IStellarView<TViewModel>
+    where TViewModel : class
+{
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public ViewManager<TViewModel> ViewManager { get; } = new WpfViewManager<TViewModel>();
+
+    public IObservable<Unit> UserControlInitialized => ViewManager.Initialized;
+
+    public IObservable<Unit> Activated => ViewManager.Activated;
+
+    public IObservable<Unit> Deactivated => ViewManager.Deactivated;
+
+    public IObservable<Unit> Disposed => ViewManager.Disposed;
+
+    public IObservable<LifecycleEvent> LifecycleEvents => ViewManager.LifecycleEvents;
+
+    protected UserControlBase()
+    {
+        Loaded += HandleLoaded;
+        Unloaded += HandleUnloaded;
+        DataContextChanged += HandleDataContextChanged;
+    }
+
+    public virtual void Initialize()
+    {
+    }
+
+    public abstract void SetupUserInterface();
+
+    public abstract void Bind(WeakCompositeDisposable disposables);
+
+    protected abstract void MapDataModelToViewModel(TViewModel viewModel, TDataModel dataModel);
+
+    protected override void OnPropertyChanged(DependencyPropertyChangedEventArgs e)
+    {
+        ViewManager.PropertyChanged(this, e.Property.Name);
+
+        base.OnPropertyChanged(e);
+    }
+
+    private void HandleLoaded(object sender, RoutedEventArgs e)
+    {
+        ViewManager.HandleActivated(this);
+
+        ViewManager.OnLifecycle(this, LifecycleEvent.IsAppearing);
+    }
+
+    private void HandleUnloaded(object sender, RoutedEventArgs e)
+    {
+        ViewManager.OnLifecycle(this, LifecycleEvent.IsDisappearing);
+
+        ViewManager.HandleDeactivated(this);
+    }
+
+    private void HandleDataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
+    {
+        if (ViewModel is not null && e.NewValue is TDataModel dataModel)
+        {
+            MapDataModelToViewModel(ViewModel, dataModel);
+        }
+    }
+}

--- a/Stellar.Wpf/WindowBase.cs
+++ b/Stellar.Wpf/WindowBase.cs
@@ -1,0 +1,83 @@
+using System.ComponentModel;
+using System.Windows;
+using ReactiveUI.Reactive;
+
+namespace Stellar.Wpf;
+
+// ReactiveWindow supplies the ViewModel dependency property and IViewFor plumbing;
+// Stellar layers its ViewManager lifecycle on top, mirroring Stellar.Avalonia's WindowBase.
+public abstract class WindowBase<TViewModel> : ReactiveWindow<TViewModel>, IStellarView<TViewModel>
+    where TViewModel : class
+{
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public ViewManager<TViewModel> ViewManager { get; } = new WpfViewManager<TViewModel>();
+
+    public IObservable<Unit> WindowInitialized => ViewManager.Initialized;
+
+    public IObservable<Unit> WindowActivated => ViewManager.Activated;
+
+    public IObservable<Unit> WindowDeactivated => ViewManager.Deactivated;
+
+    public IObservable<Unit> IsAppearing => ViewManager.IsAppearing;
+
+    public IObservable<Unit> IsDisappearing => ViewManager.IsDisappearing;
+
+    public IObservable<Unit> Disposed => ViewManager.Disposed;
+
+    public IObservable<LifecycleEvent> LifecycleEvents => ViewManager.LifecycleEvents;
+
+    protected WindowBase()
+        : this(manuallyInitialize: true)
+    {
+    }
+
+    protected WindowBase(
+        TViewModel? viewModel = null,
+        bool maintain = false,
+        bool delayBindingRegistrationUntilAttached = false,
+        bool manuallyInitialize = true)
+    {
+        if (!manuallyInitialize)
+        {
+            this.InitializeStellarComponent(viewModel, maintain, delayBindingRegistrationUntilAttached);
+        }
+    }
+
+    public virtual void Initialize()
+    {
+    }
+
+    public abstract void SetupUserInterface();
+
+    public abstract void Bind(WeakCompositeDisposable disposables);
+
+    protected override void OnInitialized(EventArgs e)
+    {
+        base.OnInitialized(e);
+
+        ViewManager.HandleActivated(this);
+    }
+
+    protected override void OnContentRendered(EventArgs e)
+    {
+        base.OnContentRendered(e);
+
+        ViewManager.OnLifecycle(this, LifecycleEvent.IsAppearing);
+    }
+
+    protected override void OnClosing(CancelEventArgs e)
+    {
+        ViewManager.OnLifecycle(this, LifecycleEvent.IsDisappearing);
+
+        ViewManager.HandleDeactivated(this);
+
+        base.OnClosing(e);
+    }
+
+    protected override void OnPropertyChanged(DependencyPropertyChangedEventArgs e)
+    {
+        ViewManager.PropertyChanged(this, e.Property.Name);
+
+        base.OnPropertyChanged(e);
+    }
+}

--- a/Stellar.Wpf/WpfViewManager.cs
+++ b/Stellar.Wpf/WpfViewManager.cs
@@ -1,0 +1,60 @@
+using System.Windows;
+
+namespace Stellar.Wpf;
+
+public class WpfViewManager<TViewModel> : ViewManager<TViewModel>
+    where TViewModel : class
+{
+    // Null whenever no view is activated, which HandleDeactivated relies on.
+    private IStellarView<TViewModel>? _view;
+
+    public override void HandleActivated(IStellarView<TViewModel> view)
+    {
+        base.HandleActivated(view);
+
+        if (HotReloadService.HotReloadAware)
+        {
+            _view = view;
+            HotReloadService.UpdateApplicationEvent -= HandleHotReload;
+            HotReloadService.UpdateApplicationEvent += HandleHotReload;
+        }
+    }
+
+    public override void HandleDeactivated(IStellarView<TViewModel> view)
+    {
+        if (HotReloadService.HotReloadAware)
+        {
+            _view = null;
+            HotReloadService.UpdateApplicationEvent -= HandleHotReload;
+        }
+
+        base.HandleDeactivated(view);
+    }
+
+#pragma warning disable CS8632 // The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
+    private void HandleHotReload(Type[]? updatedTypes)
+#pragma warning restore CS8632 // The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
+    {
+        if (_view is null)
+        {
+            return;
+        }
+
+        Application.Current?.Dispatcher
+            .Invoke(
+                () =>
+                {
+                    var maintainStatus = _view.ViewManager.Maintain;
+
+                    _view.ViewManager.Maintain = false;
+
+                    _view.ViewManager.UnregisterBindings(_view);
+
+                    _view.ViewManager.Maintain = maintainStatus;
+
+                    _view.SetupUserInterface();
+
+                    _view.ViewManager.RegisterBindings(_view);
+                });
+    }
+}

--- a/Stellar.sln
+++ b/Stellar.sln
@@ -49,6 +49,12 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Stellar.DiskDataCache", "St
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Stellar.SourceGenerators", "Stellar.SourceGenerators\Stellar.SourceGenerators.csproj", "{037D57FD-AB7C-4F69-8841-1A655FC86145}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Stellar.Wpf", "Stellar.Wpf\Stellar.Wpf.csproj", "{D3E861EB-BBD7-405F-AB85-04F928E39E38}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Stellar.WinUI", "Stellar.WinUI\Stellar.WinUI.csproj", "{B51B97EC-F16B-4092-950D-260D71CF7A65}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Stellar.Uno", "Stellar.Uno\Stellar.Uno.csproj", "{51D9C2E2-D338-45BF-B904-5C8B1DDF68FF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -216,6 +222,42 @@ Global
 		{037D57FD-AB7C-4F69-8841-1A655FC86145}.Release|x64.Build.0 = Release|Any CPU
 		{037D57FD-AB7C-4F69-8841-1A655FC86145}.Release|x86.ActiveCfg = Release|Any CPU
 		{037D57FD-AB7C-4F69-8841-1A655FC86145}.Release|x86.Build.0 = Release|Any CPU
+		{D3E861EB-BBD7-405F-AB85-04F928E39E38}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D3E861EB-BBD7-405F-AB85-04F928E39E38}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D3E861EB-BBD7-405F-AB85-04F928E39E38}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D3E861EB-BBD7-405F-AB85-04F928E39E38}.Debug|x64.Build.0 = Debug|Any CPU
+		{D3E861EB-BBD7-405F-AB85-04F928E39E38}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D3E861EB-BBD7-405F-AB85-04F928E39E38}.Debug|x86.Build.0 = Debug|Any CPU
+		{D3E861EB-BBD7-405F-AB85-04F928E39E38}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D3E861EB-BBD7-405F-AB85-04F928E39E38}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D3E861EB-BBD7-405F-AB85-04F928E39E38}.Release|x64.ActiveCfg = Release|Any CPU
+		{D3E861EB-BBD7-405F-AB85-04F928E39E38}.Release|x64.Build.0 = Release|Any CPU
+		{D3E861EB-BBD7-405F-AB85-04F928E39E38}.Release|x86.ActiveCfg = Release|Any CPU
+		{D3E861EB-BBD7-405F-AB85-04F928E39E38}.Release|x86.Build.0 = Release|Any CPU
+		{B51B97EC-F16B-4092-950D-260D71CF7A65}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B51B97EC-F16B-4092-950D-260D71CF7A65}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B51B97EC-F16B-4092-950D-260D71CF7A65}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B51B97EC-F16B-4092-950D-260D71CF7A65}.Debug|x64.Build.0 = Debug|Any CPU
+		{B51B97EC-F16B-4092-950D-260D71CF7A65}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B51B97EC-F16B-4092-950D-260D71CF7A65}.Debug|x86.Build.0 = Debug|Any CPU
+		{B51B97EC-F16B-4092-950D-260D71CF7A65}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B51B97EC-F16B-4092-950D-260D71CF7A65}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B51B97EC-F16B-4092-950D-260D71CF7A65}.Release|x64.ActiveCfg = Release|Any CPU
+		{B51B97EC-F16B-4092-950D-260D71CF7A65}.Release|x64.Build.0 = Release|Any CPU
+		{B51B97EC-F16B-4092-950D-260D71CF7A65}.Release|x86.ActiveCfg = Release|Any CPU
+		{B51B97EC-F16B-4092-950D-260D71CF7A65}.Release|x86.Build.0 = Release|Any CPU
+		{51D9C2E2-D338-45BF-B904-5C8B1DDF68FF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{51D9C2E2-D338-45BF-B904-5C8B1DDF68FF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{51D9C2E2-D338-45BF-B904-5C8B1DDF68FF}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{51D9C2E2-D338-45BF-B904-5C8B1DDF68FF}.Debug|x64.Build.0 = Debug|Any CPU
+		{51D9C2E2-D338-45BF-B904-5C8B1DDF68FF}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{51D9C2E2-D338-45BF-B904-5C8B1DDF68FF}.Debug|x86.Build.0 = Debug|Any CPU
+		{51D9C2E2-D338-45BF-B904-5C8B1DDF68FF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{51D9C2E2-D338-45BF-B904-5C8B1DDF68FF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{51D9C2E2-D338-45BF-B904-5C8B1DDF68FF}.Release|x64.ActiveCfg = Release|Any CPU
+		{51D9C2E2-D338-45BF-B904-5C8B1DDF68FF}.Release|x64.Build.0 = Release|Any CPU
+		{51D9C2E2-D338-45BF-B904-5C8B1DDF68FF}.Release|x86.ActiveCfg = Release|Any CPU
+		{51D9C2E2-D338-45BF-B904-5C8B1DDF68FF}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Stellar.slnf
+++ b/Stellar.slnf
@@ -10,7 +10,10 @@
       "Stellar.DiskDataCache\\Stellar.DiskDataCache.csproj",
       "Stellar.FluentValidation\\Stellar.FluentValidation.csproj",
       "Stellar.SourceGenerators\\Stellar.SourceGenerators.csproj",
-      "Stellar.UnitTests\\Stellar.UnitTests.csproj"
+      "Stellar.UnitTests\\Stellar.UnitTests.csproj",
+      "Stellar.Uno\\Stellar.Uno.csproj",
+      "Stellar.WinUI\\Stellar.WinUI.csproj",
+      "Stellar.Wpf\\Stellar.Wpf.csproj"
     ]
   }
 }

--- a/Stellar/GlobalUsings.cs
+++ b/Stellar/GlobalUsings.cs
@@ -6,3 +6,4 @@ global using System.Reactive.Disposables;
 global using System.Reactive.Linq;
 global using ReactiveGenerator;
 global using ReactiveUI;
+global using ReactiveUI.Reactive;

--- a/Stellar/Stellar.csproj
+++ b/Stellar/Stellar.csproj
@@ -18,7 +18,8 @@
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="ReactiveUI" />
+        <PackageReference Include="ReactiveUI.Reactive" />
+        <PackageReference Include="System.Reactive" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary

Major-version migration plus three new platform packages, targeting v2.0.0.

### ReactiveUI 23.2.28 → 24.0.0 (`.Reactive` distribution)

ReactiveUI 24 re-platformed onto the new `ReactiveUI.Primitives` engine and split into two package families. Stellar adopts the **`.Reactive` family** (`ReactiveUI.Reactive`, `ReactiveUI.Maui.Reactive`, `ReactiveUI.Blazor.Reactive`):

- Same engine and hot-path performance gains as the default packages (3–4× faster `WhenAnyValue`/`ToProperty` per upstream benchmarks) — both distributions run on Primitives.
- Keeps the System.Reactive 7 types (`Unit`, `IScheduler`, `Subject<T>`) that Stellar's public API is built on; the default family would have changed them to `RxVoid`/`ISequencer`/`Signal<T>` across the entire API surface.
- `System.Reactive` 7.0.0 is now a **direct** dependency (no longer flows transitively).

**Consumer impact:** consumers add `global using ReactiveUI.Reactive;`. That one line also fixes code emitted by ReactiveGenerator / ReactiveUI.SourceGenerators, which still generate 23-era `RaiseAndSetIfChanged` calls against `using ReactiveUI;` (global usings apply to generated files).

### Avalonia 11.3.18 → 12.1.1, Avalonia.ReactiveUI removed

Avalonia.ReactiveUI has no release compatible with ReactiveUI 24 (or Avalonia 12), so the dependency is gone. Stellar.Avalonia now owns the pieces it used: `WindowBase`/`UserControlBase` implement `IViewFor` directly, plus its own `AvaloniaScheduler` and `AvaloniaActivationForViewFetcher`. Removing the dependency is what unlocked Avalonia 12. `Avalonia.Diagnostics` dropped (discontinued after 11.3; was referenced but unused).

### New platform heads: StellarUI.Wpf, StellarUI.WinUI, StellarUI.Uno

Mirror the existing per-platform pattern (ViewManager + base classes + builder extensions):

- **Stellar.Wpf** — `ReactiveUI.WPF.Reactive`. Targets `net10.0-windows10.0.19041.0`; the plain `net10.0-windows` TFM silently resolves the package's .NET Framework assets (NU1701).
- **Stellar.WinUI** — `ReactiveUI.WinUI.Reactive` + WindowsAppSDK 2.3.1; PRI/MSIX tooling disabled on non-Windows hosts so it cross-compiles on the mac/linux runners.
- **Stellar.Uno** — Uno.WinUI 6.6.176; no ReactiveUI 24-compatible Uno package exists, so it hand-rolls activation fetcher + scheduler the same way Stellar.Avalonia does.

All three are wired into `Stellar.sln`, `Stellar.slnf` (so the ubuntu CI job builds them), and the `nuget.yml` release matrix — which previously would have **silently skipped them** on a `v*` tag.

### Other upgrades

| Package | Before | After |
|---|---|---|
| ReactiveUI / .Maui / .Blazor | 23.2.28 | 24.0.0 (`.Reactive`) |
| Avalonia + companions | 11.3.18 | 12.1.1 |
| CommunityToolkit.Maui | 14.2.2 | 15.0.0 |
| CommunityToolkit.Maui.Markup | 7.0.1 | 8.0.0 |
| System.Reactive | (transitive) | 7.0.0 direct |

Everything else already latest stable. Deliberate pins kept: `Microsoft.CodeAnalysis.CSharp` 5.0.0 (SDK feature-band loading), stylecop beta. ReactiveUI 24 also dropped `ReactiveViewCell`; Stellar.Maui ships its own now.

## Validation

- Release build of `Stellar.slnf` on macOS **and** in a Linux `dotnet/sdk:10.0` container (ubuntu CI parity)
- 259/259 unit tests pass (Release)
- Pack rehearsal: all 9 non-MAUI release-matrix projects produce nupkgs
- `Stellar.Maui` + `Stellar.Maui.PopUp` Release builds for `net10.0-android` and `net10.0-ios`
- MauiSample / MauiBlazorHybridSample / AvaloniaSample / BlazorSample build

**Compile-verified only** (no local workload/runner): maccatalyst TFMs and Windows runtime behavior of the WPF/WinUI heads. Worth a `windows-latest` CI job before tagging v2.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)