### PR TITLE
Fix build break from auto-fix commits (v2.1.3 release failed; 2.1.3 partially published)

### DIFF
--- a/Stellar.Avalonia/AvaloniaObjectObservableForProperty.cs
+++ b/Stellar.Avalonia/AvaloniaObjectObservableForProperty.cs
@@ -38,33 +38,37 @@ public sealed class AvaloniaObjectObservableForProperty : ICreatesObservableForP
     public IObservable<IObservedChange<object?, object?>> GetNotificationForProperty(object sender, Expression expression, string propertyName, bool beforeChanged) =>
         GetNotificationForProperty(sender, expression, propertyName, beforeChanged, suppressWarnings: false);
 
-public IObservable<IObservedChange<object?, object?>> GetNotificationForProperty(object sender, Expression expression, string propertyName, bool beforeChanged, bool suppressWarnings)
-{
-    if (beforeChanged)
+    public IObservable<IObservedChange<object?, object?>> GetNotificationForProperty(object sender, Expression expression, string propertyName, bool beforeChanged, bool suppressWarnings)
     {
-        return Observable.Never<IObservedChange<object?, object?>>();
-    }
-
-    if (sender is not AvaloniaObject avaloniaObject)
-    {
-        throw new ArgumentException($"Sender must be an AvaloniaObject, but was {sender?.GetType().FullName ?? \"null\"}.", nameof(sender));
-    }
-
-    var property = AvaloniaPropertyRegistry.Instance.FindRegistered(sender.GetType(), propertyName);
-
-    if (property is null)
-    {
-        if (suppressWarnings)
+        // GetAffinityForObject already declines beforeChanged requests, so this is
+        // defensive: the PropertyChanged event cannot report values before they change.
+        if (beforeChanged)
         {
             return Observable.Never<IObservedChange<object?, object?>>();
         }
 
-        throw new ArgumentException($"No AvaloniaProperty named '{propertyName}' is registered on {sender.GetType().FullName}.", nameof(propertyName));
-    }
+        if (sender is not AvaloniaObject avaloniaObject)
+        {
+            throw new ArgumentException($"Sender must be an AvaloniaObject, but was {sender?.GetType().FullName ?? "null"}.", nameof(sender));
+        }
+
+        var property = AvaloniaPropertyRegistry.Instance.FindRegistered(sender.GetType(), propertyName);
+
+        if (property is null)
+        {
+            if (suppressWarnings)
+            {
+                return Observable.Never<IObservedChange<object?, object?>>();
+            }
+
+            throw new ArgumentException($"No AvaloniaProperty named '{propertyName}' is registered on {sender.GetType().FullName}.", nameof(propertyName));
+        }
+
         return Observable.Create<IObservedChange<object?, object?>>(
             observer =>
             {
-void Handler(object? _, AvaloniaPropertyChangedEventArgs args)
+                void Handler(object? handlerSender, AvaloniaPropertyChangedEventArgs args)
+                {
                     if (args.Property == property)
                     {
                         observer.OnNext(new ObservedChange<object?, object?>(sender, expression, default));

--- a/Stellar.Uno/DependencyObjectObservableForProperty.cs
+++ b/Stellar.Uno/DependencyObjectObservableForProperty.cs
@@ -38,29 +38,32 @@ public sealed class DependencyObjectObservableForProperty : ICreatesObservableFo
     public IObservable<IObservedChange<object?, object?>> GetNotificationForProperty(object sender, Expression expression, string propertyName, bool beforeChanged) =>
         GetNotificationForProperty(sender, expression, propertyName, beforeChanged, suppressWarnings: false);
 
-public IObservable<IObservedChange<object?, object?>> GetNotificationForProperty(object sender, Expression expression, string propertyName, bool beforeChanged, bool suppressWarnings)
-{
-    if (beforeChanged)
+    public IObservable<IObservedChange<object?, object?>> GetNotificationForProperty(object sender, Expression expression, string propertyName, bool beforeChanged, bool suppressWarnings)
     {
-        return Observable.Never<IObservedChange<object?, object?>>();
-    }
-
-    if (sender is not DependencyObject dependencyObject)
-    {
-        throw new ArgumentException($"Sender must be a DependencyObject, but was {sender?.GetType().FullName ?? \"null\"}.", nameof(sender));
-    }
-
-    var dependencyProperty = GetDependencyProperty(sender.GetType(), propertyName);
-
-    if (dependencyProperty is null)
-    {
-        if (suppressWarnings)
+        // GetAffinityForObject already declines beforeChanged requests, so this is
+        // defensive: DependencyProperty callbacks fire only after a value changes.
+        if (beforeChanged)
         {
             return Observable.Never<IObservedChange<object?, object?>>();
         }
 
-        throw new ArgumentException($"No DependencyProperty named '{propertyName}Property' was found on {sender.GetType().FullName}.", nameof(propertyName));
-    }
+        if (sender is not DependencyObject dependencyObject)
+        {
+            throw new ArgumentException($"Sender must be a DependencyObject, but was {sender?.GetType().FullName ?? "null"}.", nameof(sender));
+        }
+
+        var dependencyProperty = GetDependencyProperty(sender.GetType(), propertyName);
+
+        if (dependencyProperty is null)
+        {
+            if (suppressWarnings)
+            {
+                return Observable.Never<IObservedChange<object?, object?>>();
+            }
+
+            throw new ArgumentException($"No DependencyProperty named '{propertyName}Property' was found on {sender.GetType().FullName}.", nameof(propertyName));
+        }
+
         return Observable.Create<IObservedChange<object?, object?>>(
             observer =>
             {


### PR DESCRIPTION
## The v2.1.3 release failed and left NuGet in a partial state

`Stellar.Avalonia` failed to compile in the tag release run ([run 31336102154](https://github.com/TheEightBot/StellarUI/actions/runs/31336102154)). The pack matrix has no `fail-fast: false`, so the failure cancelled the remaining jobs — but four had already pushed.

**Live on nuget.org at 2.1.3:** `StellarUI`, `StellarUI.Maui`, `StellarUI.WinUI`, `StellarUI.FluentValidation`
**Never shipped:** `StellarUI.Uno`, `StellarUI.Avalonia`, `StellarUI.Wpf`, `StellarUI.Blazor`, `StellarUI.DiskDataCache`, `StellarUI.SourceGenerators`, `StellarUI.Maui.PopUp`

Notably `StellarUI.Uno` — the package carrying the `WhenAnyValue` fix — is one of the missing ones.

## Cause

The three `Potential fix for pull request finding` commits on #37 rewrote both `ICreatesObservableForProperty` implementations and introduced, in each file:

- **quotes escaped inside an interpolated string** — `$"... {sender?.GetType().FullName ?? \"null\"}."` → `error CS1056: Unexpected character '\'`
- **the opening brace of the `Handler` local function deleted** (Avalonia) → cascading brace errors
- **the SA1313 parameter-naming fix reverted** (Avalonia), reintroducing the StyleCop error
- methods dedented out of their class indentation

22 compiler errors reproduce locally on `develop`.

## This PR

Restores valid syntax while **keeping the two guards those commits legitimately added**:
- `beforeChanged` → `Observable.Never` (defensive; `GetAffinityForObject` already declines those requests)
- honouring `suppressWarnings` when the property isn't registered, rather than always throwing

## Verification

- Release build of `Stellar.slnf` — succeeds (vs. 22 errors on `develop`)
- 259/259 unit tests pass
- Pack rehearsal: `Stellar`, `Stellar.Avalonia`, `Stellar.Uno` all produce nupkgs
- Live Uno desktop runtime test still passes: control-rooted `WhenAnyValue` 3/3 emissions, background→UI scheduler marshaling, full Stellar lifecycle

## After merging

`2.1.3` is burned for the four packages already on nuget.org (NuGet allows unlisting, not deletion), so **cut `v2.1.4`** rather than retagging.

Worth considering separately: the release matrix pushes each package as its own job, so any single failure yields a partially-published version. Building all projects before pushing any would make releases atomic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)